### PR TITLE
Haxe 3 compatibility

### DIFF
--- a/src/utest/Assertation.hx
+++ b/src/utest/Assertation.hx
@@ -1,7 +1,12 @@
 package utest;
 
 import haxe.PosInfos;
+
+#if haxe_211
+import haxe.CallStack;
+#else
 import haxe.Stack;
+#end
 
 /**
 * Enumerates the states available as a result of

--- a/src/utest/TestHandler.hx
+++ b/src/utest/TestHandler.hx
@@ -41,7 +41,11 @@ class TestHandler<T> {
 	
 	static function exceptionStack(pops = 2)
 	{
+		#if haxe_211
+		var stack = haxe.CallStack.exceptionStack();
+		#else
 		var stack = haxe.Stack.exceptionStack();
+		#end
 		while (pops-- > 0)
 		{
 			stack.pop();

--- a/src/utest/ui/macro/MacroReport.hx
+++ b/src/utest/ui/macro/MacroReport.hx
@@ -3,7 +3,12 @@ package utest.ui.macro;
 #if macro
 import haxe.macro.Context;
 import neko.Lib;
+
+#if haxe_211
+import haxe.CallStack;
+#else
 import haxe.Stack;
+#end
 
 import utest.Runner;
 import utest.TestResult;

--- a/src/utest/ui/text/HtmlReport.hx
+++ b/src/utest/ui/text/HtmlReport.hx
@@ -1,4 +1,4 @@
-﻿package utest.ui.text;
+package utest.ui.text;
 
 import haxe.PosInfos;
 import haxe.Timer;
@@ -12,7 +12,12 @@ import utest.TestResult;
 import utest.ui.common.ResultAggregator;
 import utest.ui.common.PackageResult;
 import utest.ui.common.ResultStats;
+
+#if haxe_211
+import haxe.CallStack;
+#else
 import haxe.Stack;
+#end
 
 using utest.ui.common.ReportTools;
 
@@ -86,7 +91,7 @@ class HtmlReport implements IReport < HtmlReport > {
 			infos : infos,
 			time : time - startTime,
 			delta : delta,
-			stack : Stack.callStack()
+			stack : #if haxe_211 CallStack.callStack() #else Stack.callStack() #end
 		} );
 		_traceTime = Timer.stamp();
 	}
@@ -155,7 +160,7 @@ class HtmlReport implements IReport < HtmlReport > {
 		var nl = addNL ? '\n' : '';
 		var last = null;
 		var count = 1;
-		for (part in Stack.toString(stack).split('\n'))
+		for (part in #if haxe_211 CallStack #else Stack #end .toString(stack).split('\n'))
 		{
 			if (StringTools.trim(part) == '')
 				continue;

--- a/src/utest/ui/text/PlainTextReport.hx
+++ b/src/utest/ui/text/PlainTextReport.hx
@@ -9,7 +9,12 @@ import utest.TestResult;
 import utest.ui.common.ResultAggregator;
 using utest.ui.common.ReportTools;
 import utest.ui.common.PackageResult;
+
+#if haxe_211
+import haxe.CallStack;
+#else
 import haxe.Stack;
+#end
 
 /**
 * @todo add documentation
@@ -54,7 +59,11 @@ class PlainTextReport implements IReport<PlainTextReport> {
 		if (stack.length == 0)
 			return "";
 		
+		#if haxe_211
+		var parts = CallStack.toString(stack).split("\n");
+		#else
 		var parts = Stack.toString(stack).split("\n");
+		#end
 		var r = [];
 		for (part in parts)
 		{

--- a/src/utest/ui/text/PrintReport.hx
+++ b/src/utest/ui/text/PrintReport.hx
@@ -1,4 +1,4 @@
-﻿package utest.ui.text;
+package utest.ui.text;
 
 import haxe.PosInfos;
 
@@ -6,7 +6,12 @@ import utest.Runner;
 import utest.TestResult;
 import utest.ui.common.ResultAggregator;
 import utest.ui.common.PackageResult;
+
+#if haxe_211
+import haxe.CallStack;
+#else
 import haxe.Stack;
+#end
 
 #if php
 import php.Lib;

--- a/tests/utest/TestAssert.hx
+++ b/tests/utest/TestAssert.hx
@@ -202,8 +202,8 @@ class TestAssert {
 		Assert.same(list1, list3, false);
 		Assert.same(list1, list3, true);
 
-		Assert.same(new IntIter(0,3), new IntIter(0,3));
-		Assert.same(new IntIter(0,3), new IntIter(0,4));
+		Assert.same(0...3, 0...3);
+		Assert.same(0...3, 0...4);
 
 		restore();
 		expect(3, 2);


### PR DESCRIPTION
Mainly solved the problem of `haxe.Stack` being renamed to `haxe.CallStack`.

Not sure if the tests in _tests_ folder need to be maintained or not?
There are some haxe 3 changes, like pattern matching, break a quite a few parts of them...

PS. Textmate seems changed the line endings... Please append `?w=1` to the url to ignore whitespace diff and see the actual change.
