### PR TITLE
Add an "onPrecheck" dispatcher for TestHandler and TestRunner.

### DIFF
--- a/src/utest/Runner.hx
+++ b/src/utest/Runner.hx
@@ -26,10 +26,19 @@ class Runner {
 	* performed during the tests.
 	*/
 	public var onComplete(default, null) : Dispatcher<Runner>;
+
+	/**
+	* Event object that monitors when a handler has executed a test case, and
+	* is about to evaluate the results.  Useful for mocking certain
+	* custom asynchronouse behavior in order for certain tests to pass.
+	*/
+	public var onPrecheck(default, null) : Dispatcher<TestHandler<TestFixture<Dynamic>>>;
+
 	/**
 	* The number of fixtures registered.
 	*/
 	public var length(default, null)      : Int;
+
 	/**
 	* Instantiates a Runner onject.
 	*/
@@ -38,6 +47,7 @@ class Runner {
 		onProgress = new Dispatcher();
 		onStart    = new Dispatcher();
 		onComplete = new Dispatcher();
+		onPrecheck = new Dispatcher();
 		length = 0;
 	}
 
@@ -101,6 +111,9 @@ class Runner {
 
 	function runFixture(fixture : TestFixture<Dynamic>) {
 		var handler = new TestHandler(fixture);
+		handler.onPrecheck.add(function(x){
+            this.onPrecheck.dispatch(x);
+        });
 		handler.execute();
 		return handler;
 	}
@@ -122,6 +135,9 @@ class Runner {
 	function runFixture(fixture : TestFixture<Dynamic>) {
 		var handler = new TestHandler(fixture);
 		handler.onComplete.add(testComplete);
+		handler.onPrecheck.add(function(x){
+            this.onPrecheck.dispatch(x);
+        });
 		handler.execute();
 	}
 

--- a/src/utest/TestHandler.hx
+++ b/src/utest/TestHandler.hx
@@ -14,6 +14,9 @@ class TestHandler<T> {
 	public var onTested(default, null) : Dispatcher<TestHandler<T>>;
 	public var onTimeout(default, null) : Dispatcher<TestHandler<T>>;
 	public var onComplete(default, null) : Dispatcher<TestHandler<T>>;
+	public var onPrecheck(default, null) : Dispatcher<TestHandler<T>>;
+
+	public var precheck(default, null) : Void->Void;
 
 	public function new(fixture : TestFixture<T>) {
 		if(fixture == null) throw "fixture argument is null";
@@ -23,6 +26,7 @@ class TestHandler<T> {
 		onTested   = new Dispatcher();
 		onTimeout  = new Dispatcher();
 		onComplete = new Dispatcher();
+		onPrecheck = new Dispatcher();
 	}
 
 	public function execute() {
@@ -36,6 +40,7 @@ class TestHandler<T> {
 		} catch(e : Dynamic) {
 			results.add(SetupError(e, exceptionStack()));
 		}
+		onPrecheck.dispatch(this);
 		checkTested();
 	}
 


### PR DESCRIPTION
This will fire before a test is evaluated, and aids in the setup of
certain custom asynchronous tests.

TestRunner's onPreheck is global across all handlers, while the TestHandler's
version only applies to itself.
