### PR TITLE
Add an Assert.pass() method

### DIFF
--- a/src/utest/Assert.hx
+++ b/src/utest/Assert.hx
@@ -638,6 +638,16 @@ Checks that the expected values is contained in value.
   }
 
 /**
+Adds a successful assertion for cases where there are no values to assert.
+@param msg: An optional success message. If not passed a default one will be used
+@param pos: Code position where the Assert call has been executed. Don't fill it
+unless you know what you are doing.
+*/
+  public static function pass(msg = "pass expected", ?pos : PosInfos) {
+    isTrue(true, msg, pos);
+  }
+
+/**
 Forces a failure.
 @param msg: An optional error message. If not passed a default one will be used
 @param pos: Code position where the Assert call has been executed. Don't fill it

--- a/test/utest/TestAssert.hx
+++ b/test/utest/TestAssert.hx
@@ -295,6 +295,13 @@ class TestAssert {
     expect(expectedsuccess, i-expectedsuccess);
   }
 
+  public function testPass() {
+    bypass();
+    Assert.pass();
+    restore();
+    expect(1, 0);
+  }
+
   public function testFail() {
     bypass();
     Assert.fail();


### PR DESCRIPTION
For some async tests, it was nice to have a way to say a test passed without asserting any values.  Also, useful to get around the warning that there were no assertions in a test.
