### PR TITLE
Async setup/teardown functions

### DIFF
--- a/src/utest/Runner.hx
+++ b/src/utest/Runner.hx
@@ -78,26 +78,32 @@ Adds a new test case.
 @param  prefix: prefix for methods that are tests (defaults to "test")
 @param  pattern: a regular expression that discriminates the names of test
       functions; when set,  the prefix parameter is meaningless
+@param  setupAsync: string name of the asynchronous setup function (defaults to "setupAsync")
+@param  teardownAsync: string name of the asynchronous teardown function (defaults to "teardownAsync")
 */
-  public function addCase(test : Dynamic, setup = "setup", teardown = "teardown", prefix = "test", ?pattern : EReg) {
+  public function addCase(test : Dynamic, setup = "setup", teardown = "teardown", prefix = "test", ?pattern : EReg, setupAsync = "setupAsync", teardownAsync = "teardownAsync") {
     if(!Reflect.isObject(test)) throw "can't add a null object as a test case";
     if(!isMethod(test, setup))
       setup = null;
+    if(!isMethod(test, setupAsync))
+      setupAsync = null;
     if(!isMethod(test, teardown))
       teardown = null;
+    if(!isMethod(test, teardownAsync))
+      teardownAsync = null;
     var fields = Type.getInstanceFields(Type.getClass(test));
     if(globalPattern == null && pattern == null) {
       for(field in fields) {
         if(!StringTools.startsWith(field, prefix)) continue;
         if(!isMethod(test, field)) continue;
-        addFixture(new TestFixture(test, field, setup, teardown));
+        addFixture(new TestFixture(test, field, setup, teardown, setupAsync, teardownAsync));
       }
     } else {
       pattern = globalPattern != null ? globalPattern : pattern;
       for(field in fields) {
         if(!pattern.match(field)) continue;
         if(!isMethod(test, field)) continue;
-        addFixture(new TestFixture(test, field, setup, teardown));
+        addFixture(new TestFixture(test, field, setup, teardown, setupAsync, teardownAsync));
       }
     }
   }

--- a/src/utest/TestFixture.hx
+++ b/src/utest/TestFixture.hx
@@ -1,15 +1,19 @@
 package utest;
 
 class TestFixture {
-  public var target(default, null)   : {};
-  public var method(default, null)   : String;
-  public var setup(default, null)    : String;
-  public var teardown(default, null) : String;
-  public function new(target : {}, method : String, ?setup : String, ?teardown : String) {
-    this.target   = target;
-    this.method   = method;
-    this.setup    = setup;
-    this.teardown = teardown;
+  public var target(default, null)        : {};
+  public var method(default, null)        : String;
+  public var setup(default, null)         : String;
+  public var setupAsync(default, null)    : String;
+  public var teardown(default, null)      : String;
+  public var teardownAsync(default, null) : String;
+  public function new(target : {}, method : String, ?setup : String, ?teardown : String, ?setupAsync : String, ?teardownAsync : String) {
+    this.target        = target;
+    this.method        = method;
+    this.setup         = setup;
+    this.setupAsync    = setupAsync;
+    this.teardown      = teardown;
+    this.teardownAsync = teardownAsync;
   }
 
   function checkMethod(name : String, arg : String) {

--- a/src/utest/TestHandler.hx
+++ b/src/utest/TestHandler.hx
@@ -163,8 +163,11 @@ class TestHandler<T> {
     Reflect.callMethod(fixture.target, Reflect.field(fixture.target, name), []);
   }
 
-  function executeAsyncMethod(name : String, done : Void->Void) {
-    if(name == null) return done();
+  function executeAsyncMethod(name : String, done : Void->Void) : Void {
+    if(name == null) {
+      done();
+      return;
+    }
     bindHandler();
     Reflect.callMethod(fixture.target, Reflect.field(fixture.target, name), [done]);
   }

--- a/src/utest/TestResult.hx
+++ b/src/utest/TestResult.hx
@@ -7,7 +7,9 @@ class TestResult {
   public var cls           : String;
   public var method        : String;
   public var setup         : String;
+  public var setupAsync    : String;
   public var teardown      : String;
+  public var teardownAsync : String;
   public var assertations  : List<Assertation>;
 
   public function new(){}
@@ -19,7 +21,9 @@ class TestResult {
     r.pack          = path.join('.');
     r.method        = handler.fixture.method;
     r.setup         = handler.fixture.setup;
+    r.setupAsync    = handler.fixture.setupAsync;
     r.teardown      = handler.fixture.teardown;
+    r.teardownAsync = handler.fixture.teardownAsync;
     r.assertations  = handler.results;
     return r;
   }


### PR DESCRIPTION
Fix for [#28](https://github.com/fponticelli/utest/issues/28).

The way to specify `setupAsync` and `teardownAsync` functions name is not really nice but I didn't want to break concerned methods prototypes.
