### PR TITLE
Check PlainTextReport#handler for null before invoke to prevent null pointer exceptions.

### DIFF
--- a/src/utest/ui/text/PlainTextReport.hx
+++ b/src/utest/ui/text/PlainTextReport.hx
@@ -151,7 +151,7 @@ class PlainTextReport implements IReport<PlainTextReport> {
 
   function complete(result : PackageResult) {
     this.result = result;
-    handler(this);
+    if (handler != null) handler(this);
 #if (php || neko || cpp || cs || java || python || lua)
     Sys.exit(result.stats.isOk ? 0 : 1);
 #elseif js


### PR DESCRIPTION
As handler is set externally we should always check it for null before call.