### PR TITLE
ITest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ display.hxml
 utest.zip
 .idea
 .haxelib
+dump/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ os:
 
 haxe:
   - "3.2.1"
-  - "3.4.4"
+  - "3.4.7"
   - development
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -45,28 +45,32 @@ class TestAll {
   * Every test case method name must be prefixed with `test` or `spec`;
   * If a method is prefixed with `spec` it is treated as the specification test. Every boolean binary operation will be wrapped in `Assert.isTrue()`
 
-To following method could be implemented to setup or teardown:
+To following methods could be implemented to setup or teardown:
 ```haxe
 /**
  * This method is executed once before running the first test in the current class.
- * If return type is `Void` it is treated as synchronous method.
+ * If it accepts an argument, it is treated as an asynchronous method.
  */
-function setupClass():utest.Async;
+function setupClass():Void;
+function setupClass(async:Async):Void;
 /**
  * This method is executed before each test.
- * If return type is `Void` it is treated as synchronous method.
+  * If it accepts an argument, it is treated as an asynchronous method.
  */
-function setup():utest.Async;
+function setup():Void;
+function setup(async:Async):Void;
 /**
  * This method is executed after each test.
- * If return type is `Void` it is treated as synchronous method.
+  * If it accepts an argument, it is treated as an asynchronous method.
  */
-function teardown():utest.Async;
+function teardown():Void;
+function teardown(async:Async):Void;
 /**
  * This method is executed once after the last test in the current class is finished.
- * If return type is `Void` it is treated as synchronous method.
+  * If it accepts an argument, it is treated as an asynchronous method.
  */
-function teardownClass():utest.Async;
+function teardownClass():Void;
+function teardownClass(async:Async):Void;
 ```
 
 To add all test cases from `my.pack` package use `runner.addCases(my.pack)`. Any module found in `my.pack` is treated as a test case. That means each module should contain a class implementing `utest.ITest` and that class should have the same name as the module name.
@@ -93,11 +97,13 @@ class TestCase extends utest.Test {
   }
 
   //asynchronous teardown
-  public function teardown():Async {
+  public function teardown(async:Async) {
     field = null; // not really needed
 
+    //Adjust timeout if needed. Default is 250ms.
+    async.setTimeout(1000);
+
     //simulate asynchronous teardown
-    var async = new Async(500); //timeout: 500ms (default - 250)
     haxe.Timer.delay(
       function() {
         //resolve asynchronous action
@@ -105,7 +111,6 @@ class TestCase extends utest.Test {
       },
       100
     );
-    return async;
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ class TestAll {
   * Every test case method name must be prefixed with `test` or `spec`;
   * If a method is prefixed with `spec` it is treated as the specification test. Every boolean binary operation will be wrapped in `Assert.isTrue()`
 
-To following methods could be implemented to setup or teardown:
+Following methods could be implemented to setup or teardown:
 ```haxe
 /**
  * This method is executed once before running the first test in the current class.

--- a/README.md
+++ b/README.md
@@ -39,24 +39,35 @@ class TestAll {
 ```
 
 `TestCase` must extend `utest.Test` or implement `utest.ITest`.
-```haxe
-interface ITest {
-	/** This method is executed once before running the first test in the current class */
-	function setupClass():Null<Async>;
-	/** This method is executed before each test. */
-	function setup():Null<Async>;
-	/** This method is executed after each test. */
-	function teardown():Null<Async>;
-	/** This method is executed once after the last test in the current class is finished. */
-	function teardownClass():Null<Async>;
-}
-```
-If a method of `utest.ITest` has return type `Null<utest.Async>` and it returns `null`, it is treated as a synchronous method. If it returns an instance of `utest.Async` it is treated as an asynchronous method and the next action will be performed only after the method `done()` of that `Async` instance is executed.
 
 `TestCase` needs to follow some conventions:
 
   * Every test case method name must be prefixed with `test` or `spec`;
   * If a method is prefixed with `spec` it is treated as the specification test. Every boolean binary operation will be wrapped in `Assert.isTrue()`
+
+To following method could be implemented to setup or teardown:
+```haxe
+/**
+ * This method is executed once before running the first test in the current class.
+ * If return type is `Void` it is treated as synchronous method.
+ */
+function setupClass():utest.Async;
+/**
+ * This method is executed before each test.
+ * If return type is `Void` it is treated as synchronous method.
+ */
+function setup():utest.Async;
+/**
+ * This method is executed after each test.
+ * If return type is `Void` it is treated as synchronous method.
+ */
+function teardown():utest.Async;
+/**
+ * This method is executed once after the last test in the current class is finished.
+ * If return type is `Void` it is treated as synchronous method.
+ */
+function teardownClass():utest.Async;
+```
 
 To add all test cases from `my.pack` package use `runner.addCases(my.pack)`. Any module found in `my.pack` is treated as a test case. That means each module should contain a class implementing `utest.ITest` and that class should have the same name as the module name.
 
@@ -67,9 +78,9 @@ import utest.Async;
 class TestCase extends utest.Test {
   var field : String;
 
-  override public function setup() {
+  //synchronous setup
+  public function setup() {
     field = "some";
-    return null; //setup is synchronous
   }
 
   function testFieldIsSome() {
@@ -81,6 +92,7 @@ class TestCase extends utest.Test {
     field.length > 3;
   }
 
+  //asynchronous teardown
   public function teardown():Async {
     field = null; // not really needed
 

--- a/extraParams.hxml
+++ b/extraParams.hxml
@@ -1,0 +1,1 @@
+--macro utest.utils.Macro.checkHaxe()

--- a/hxml/common.hxml
+++ b/hxml/common.hxml
@@ -2,3 +2,5 @@
 -cp test
 -main TestAll
 -D utest
+
+extraParams.hxml

--- a/src/utest/Async.hx
+++ b/src/utest/Async.hx
@@ -1,0 +1,69 @@
+package utest;
+
+import haxe.PosInfos;
+import haxe.Timer;
+
+class Async {
+	static var resolvedInstance:Async;
+
+	public var resolved(default,null):Bool = false;
+	public var timedOut(default,null):Bool = false;
+
+	var callbacks:Array<Void->Void> = [];
+	var startTime:Float;
+	var timer:Timer;
+
+	/**
+	 * Returns an instance of `Async` which is already resolved.
+	 * Any actions handling this instance will be executed synchronously.
+	 */
+	static public function getResolved():Async {
+		if(resolvedInstance == null) {
+			resolvedInstance = new Async();
+			resolvedInstance.done();
+		}
+		return resolvedInstance;
+	}
+
+	public function new(timeoutMs:Int = 250) {
+		startTime = Timer.stamp();
+		start(timeoutMs);
+	}
+
+	inline function start(timeoutMs:Int) {
+		if(timer != null) timer.stop();
+		timer = Timer.delay(setTimedOutState, timeoutMs);
+	}
+
+	public function done() {
+		if(resolved) {
+			if(timedOut) {
+				throw 'Cannot resolve timed out Async.';
+			} else {
+				throw 'Async is already resolved.';
+			}
+		}
+		resolved = true;
+		for (cb in callbacks) cb();
+	}
+
+	public function setTimeout(timeoutMs:Int) {
+		var passed = Math.round(1000 * (Timer.stamp() - startTime));
+		timer.stop();
+		timer = Timer.delay(setTimedOutState, timeoutMs - passed);
+	}
+
+	public function then(cb:Void->Void) {
+		if(resolved) {
+			cb();
+		} else {
+			callbacks.push(cb);
+		}
+	}
+
+	function setTimedOutState() {
+		if(resolved) return;
+		timedOut = true;
+		done();
+	}
+}

--- a/src/utest/Async.hx
+++ b/src/utest/Async.hx
@@ -7,6 +7,7 @@ package utest;
 import haxe.PosInfos;
 import haxe.Timer;
 
+@:allow(utest)
 class Async {
 	static var resolvedInstance:Async;
 
@@ -21,7 +22,7 @@ class Async {
 	 * Returns an instance of `Async` which is already resolved.
 	 * Any actions handling this instance will be executed synchronously.
 	 */
-	static public function getResolved():Async {
+	static function getResolved():Async {
 		if(resolvedInstance == null) {
 			resolvedInstance = new Async();
 			resolvedInstance.done();
@@ -29,13 +30,8 @@ class Async {
 		return resolvedInstance;
 	}
 
-	public function new(timeoutMs:Int = 250) {
+	function new(timeoutMs:Int = 250) {
 		startTime = Timer.stamp();
-		start(timeoutMs);
-	}
-
-	inline function start(timeoutMs:Int) {
-		if(timer != null) timer.stop();
 		timer = Timer.delay(setTimedOutState, timeoutMs);
 	}
 
@@ -52,12 +48,16 @@ class Async {
 	}
 
 	public function setTimeout(timeoutMs:Int) {
-		var passed = Math.round(1000 * (Timer.stamp() - startTime));
 		timer.stop();
-		timer = Timer.delay(setTimedOutState, timeoutMs - passed);
+		var delay = timeoutMs - Math.round(1000 * (Timer.stamp() - startTime));
+		if(delay <= 0) {
+			done();
+		} else {
+			timer = Timer.delay(setTimedOutState, delay);
+		}
 	}
 
-	public function then(cb:Void->Void) {
+	function then(cb:Void->Void) {
 		if(resolved) {
 			cb();
 		} else {

--- a/src/utest/Async.hx
+++ b/src/utest/Async.hx
@@ -1,5 +1,9 @@
 package utest;
 
+#if (haxe_ver < "3.4.0")
+	#error 'Haxe 3.4.0 or later is required for utest.Async'
+#end
+
 import haxe.PosInfos;
 import haxe.Timer;
 

--- a/src/utest/ITest.hx
+++ b/src/utest/ITest.hx
@@ -12,25 +12,29 @@ package utest;
 interface ITest {
 	// /**
 	//  * This method is executed once before running the first test in the current class.
-	//  * If return type is `Void` it is treated as synchronous method.
+	//  * If it accepts an argument, it is treated as an asynchronous method.
 	//  */
-	// function setupClass():Async;
+	// function setupClass():Void;
+	// function setupClass(async:Async):Void;
 
 	// /**
 	//  * This method is executed before each test.
-	//  * If return type is `Void` it is treated as synchronous method.
+	//  * If it accepts an argument, it is treated as an asynchronous method.
 	//  */
-	// function setup():Async;
+	// function setup():Void;
+	// function setup(async:Async):Void;
 
 	// /**
 	//  * This method is executed after each test.
-	//  * If return type is `Void` it is treated as synchronous method.
+	//  * If it accepts an argument, it is treated as an asynchronous method.
 	//  */
-	// function teardown():Async;
+	// function teardown():Void;
+	// function teardown(async:Async):Void;
 
 	// /**
 	//  * This method is executed once after the last test in the current class is finished.
-	//  * If return type is `Void` it is treated as synchronous method.
+	//  * If it accepts an argument, it is treated as an asynchronous method.
 	//  */
-	// function teardownClass():Async;
+	// function teardownClass():Void;
+	// function teardownClass(async:Async):Void;
 }

--- a/src/utest/ITest.hx
+++ b/src/utest/ITest.hx
@@ -5,8 +5,8 @@ package utest;
 #end
 
 /**
- * If a method of this interface has `Null<utest.Async>` return type and it returns `null` it is treated as synchronous.
- * If it returns an instance of `utest.Async` it is treated as asynchronous and the next action will be performed
+ * If a method of this interface has `Null<utest.Async>` return type and it returns `null` it is treated as a synchronous method.
+ * If it returns an instance of `utest.Async` it is treated as an asynchronous method and the next action will be performed
  * only after the method `done()` of that instance is executed.
  */
 @:autoBuild(utest.utils.TestBuilder.build())

--- a/src/utest/ITest.hx
+++ b/src/utest/ITest.hx
@@ -5,29 +5,32 @@ package utest;
 #end
 
 /**
- * If a method of this interface has `Null<utest.Async>` return type and it returns `null` it is treated as a synchronous method.
- * If it returns an instance of `utest.Async` it is treated as an asynchronous method and the next action will be performed
- * only after the method `done()` of that instance is executed.
+ * Interface, which should be implemented by test cases.
+ *
  */
 @:autoBuild(utest.utils.TestBuilder.build())
 interface ITest {
-	/**
-	 * This method is executed once before running the first test in the current class
-	 */
-	function setupClass():Null<Async>;
+	// /**
+	//  * This method is executed once before running the first test in the current class.
+	//  * If return type is `Void` it is treated as synchronous method.
+	//  */
+	// function setupClass():Async;
 
-	/**
-	 * This method is executed before each test.
-	 */
-	function setup():Null<Async>;
+	// /**
+	//  * This method is executed before each test.
+	//  * If return type is `Void` it is treated as synchronous method.
+	//  */
+	// function setup():Async;
 
-	/**
-	 * This method is executed after each test.
-	 */
-	function teardown():Null<Async>;
+	// /**
+	//  * This method is executed after each test.
+	//  * If return type is `Void` it is treated as synchronous method.
+	//  */
+	// function teardown():Async;
 
-	/**
-	 * This method is executed once after the last test in the current class is finished.
-	 */
-	function teardownClass():Null<Async>;
+	// /**
+	//  * This method is executed once after the last test in the current class is finished.
+	//  * If return type is `Void` it is treated as synchronous method.
+	//  */
+	// function teardownClass():Async;
 }

--- a/src/utest/ITest.hx
+++ b/src/utest/ITest.hx
@@ -1,5 +1,9 @@
 package utest;
 
+#if (haxe_ver < "3.4.0")
+	#error 'Haxe 3.4.0 or later is required for utest.ITest'
+#end
+
 /**
  * If a method of this interface has `Null<utest.Async>` return type and it returns `null` it is treated as synchronous.
  * If it returns an instance of `utest.Async` it is treated as asynchronous and the next action will be performed

--- a/src/utest/ITest.hx
+++ b/src/utest/ITest.hx
@@ -1,0 +1,29 @@
+package utest;
+
+/**
+ * If a method of this interface has `Null<utest.Async>` return type and it returns `null` it is treated as synchronous.
+ * If it returns an instance of `utest.Async` it is treated as asynchronous and the next action will be performed
+ * only after the method `done()` of that instance is executed.
+ */
+@:autoBuild(utest.utils.TestBuilder.build())
+interface ITest {
+	/**
+	 * This method is executed once before running the first test in the current class
+	 */
+	function setupClass():Null<Async>;
+
+	/**
+	 * This method is executed before each test.
+	 */
+	function setup():Null<Async>;
+
+	/**
+	 * This method is executed after each test.
+	 */
+	function teardown():Null<Async>;
+
+	/**
+	 * This method is executed once after the last test in the current class is finished.
+	 */
+	function teardownClass():Null<Async>;
+}

--- a/src/utest/ITestHandler.hx
+++ b/src/utest/ITestHandler.hx
@@ -33,9 +33,8 @@ class ITestHandler<T> extends TestHandler<T> {
 	}
 
 	function runSetup() {
-		setupAsync = Async.getResolved();
 		try {
-			setupAsync = testCase.setup().orResolved();
+			setupAsync = fixture.setupMethod();
 		} catch(e:Dynamic) {
 			results.add(SetupError(e, CallStack.exceptionStack()));
 			completedFinally();
@@ -88,9 +87,8 @@ class ITestHandler<T> extends TestHandler<T> {
 	}
 
 	function runTeardown() {
-		teardownAsync = Async.getResolved();
 		try {
-			teardownAsync = testCase.teardown().orResolved();
+			teardownAsync = fixture.teardownMethod();
 		} catch(e:Dynamic) {
 			results.add(TeardownError(e, CallStack.exceptionStack()));
 			completedFinally();
@@ -102,7 +100,7 @@ class ITestHandler<T> extends TestHandler<T> {
 
 	function checkTeardown() {
 		if(teardownAsync.timedOut) {
-			results.add(SetupError('Teardown timeout', []));
+			results.add(TeardownError('Teardown timeout', []));
 		}
 		completedFinally();
 	}

--- a/src/utest/ITestHandler.hx
+++ b/src/utest/ITestHandler.hx
@@ -54,9 +54,8 @@ class ITestHandler<T> extends TestHandler<T> {
 	}
 
 	function runTest() {
-		testAsync = test.async.orResolved();
 		try {
-			test.execute();
+			testAsync = test.execute();
 		} catch(e:Dynamic) {
 			results.add(Error(e, CallStack.exceptionStack()));
 			runTeardown();

--- a/src/utest/ITestHandler.hx
+++ b/src/utest/ITestHandler.hx
@@ -1,0 +1,119 @@
+package utest;
+
+import haxe.CallStack;
+
+using utest.utils.AsyncUtils;
+
+class ITestHandler<T> extends TestHandler<T> {
+	var testCase:ITest;
+	var test:TestData;
+	var setupAsync:Null<Async>;
+	var testAsync:Null<Async>;
+	var teardownAsync:Null<Async>;
+
+	public function new(fixture:TestFixture) {
+		super(fixture);
+		if(!fixture.isITest) {
+			throw 'Invalid fixture type for utest.ITestHandler';
+		}
+		testCase = cast(fixture.target, ITest);
+		test = fixture.test;
+		if(test == null) {
+			throw 'Fixture is missing test data';
+		}
+	}
+
+	override public function execute() {
+		if (fixture.ignoringInfo.isIgnored) {
+			executeFinally();
+			return;
+		}
+		bindHandler();
+		runSetup();
+	}
+
+	function runSetup() {
+		setupAsync = Async.getResolved();
+		try {
+			setupAsync = testCase.setup().orResolved();
+		} catch(e:Dynamic) {
+			results.add(SetupError(e, CallStack.exceptionStack()));
+			completedFinally();
+			return;
+		}
+
+		setupAsync.then(checkSetup);
+	}
+
+	function checkSetup() {
+		if(setupAsync.timedOut) {
+			results.add(SetupError('Setup timeout', []));
+			completedFinally();
+		} else {
+			runTest();
+		}
+	}
+
+	function runTest() {
+		testAsync = test.async.orResolved();
+		try {
+			test.execute();
+		} catch(e:Dynamic) {
+			results.add(Error(e, CallStack.exceptionStack()));
+			runTeardown();
+			return;
+		}
+
+		testAsync.then(checkTest);
+	}
+
+	function checkTest() {
+		onPrecheck.dispatch(this);
+
+		if(testAsync.timedOut) {
+			results.add(TimeoutError(1, []));
+			onTimeout.dispatch(this);
+
+		} else if(testAsync.resolved) {
+			if(results.length == 0) {
+				results.add(Warning('no assertions'));
+			}
+			onTested.dispatch(this);
+
+		} else {
+			throw 'Unexpected test state';
+		}
+
+		runTeardown();
+	}
+
+	function runTeardown() {
+		teardownAsync = Async.getResolved();
+		try {
+			teardownAsync = testCase.teardown().orResolved();
+		} catch(e:Dynamic) {
+			results.add(TeardownError(e, CallStack.exceptionStack()));
+			completedFinally();
+			return;
+		}
+
+		teardownAsync.then(checkTeardown);
+	}
+
+	function checkTeardown() {
+		if(teardownAsync.timedOut) {
+			results.add(SetupError('Teardown timeout', []));
+		}
+		completedFinally();
+	}
+
+	override function bindHandler() {
+		if (wasBound) return;
+		Assert.results = this.results;
+		var msg = ' is not allowed in tests extending utest.ITest. Add `async:utestAsync` argument to the test method instead.';
+		Assert.createAsync = function(?f, ?t) throw 'Assert.createAsync() $msg';
+		Assert.createEvent = function(f, ?t) throw 'Assert.createEvent() $msg';
+		wasBound = true;
+	}
+
+}

--- a/src/utest/Runner.hx
+++ b/src/utest/Runner.hx
@@ -12,7 +12,9 @@ using StringTools;
 using haxe.macro.Tools;
 #end
 
+#if (haxe_ver >= "3.4.0")
 using utest.utils.AsyncUtils;
+#end
 
 /**
  * The Runner class performs a set of tests. The tests can be added using addCase or addFixtures.
@@ -23,8 +25,10 @@ using utest.utils.AsyncUtils;
  * @todo AVOID CHAINING METHODS (long chains do not work properly on IE)
  */
 class Runner {
-  var iTestFixtures:Map<ITest,Array<TestFixture>> = new Map();
   var fixtures(default, null) : Array<TestFixture> = [];
+  #if (haxe_ver >= "3.4.0")
+  var iTestFixtures:Map<ITest,Array<TestFixture>> = new Map();
+  #end
 
   /**
    * Event object that monitors the progress of the runner.
@@ -112,13 +116,18 @@ class Runner {
    * @param  teardownAsync: string name of the asynchronous teardown function (defaults to "teardownAsync")
    */
   public function addCase(test : Dynamic, setup = "setup", teardown = "teardown", prefix = "test", ?pattern : EReg, setupAsync = "setupAsync", teardownAsync = "teardownAsync") {
+    #if (haxe_ver >= "3.4.0")
     if(Std.is(test, ITest)) {
       addITest(test, pattern);
     } else {
       addCaseOld(test, setup, teardown, prefix, pattern, setupAsync, teardownAsync);
     }
+    #else
+    addCaseOld(test, setup, teardown, prefix, pattern, setupAsync, teardownAsync);
+    #end
   }
 
+  #if (haxe_ver >= "3.4.0")
   function addITest(testCase:ITest, pattern:Null<EReg>) {
     if(iTestFixtures.exists(testCase)) {
       throw 'Cannot add the same test twice.';
@@ -131,6 +140,7 @@ class Runner {
       addFixture(TestFixture.ofData(testCase, test));
     }
   }
+  #end
 
   function addCaseOld(test:Dynamic, setup = "setup", teardown = "teardown", prefix = "test", ?pattern : EReg, setupAsync = "setupAsync", teardownAsync = "teardownAsync") {
     if(!Reflect.isObject(test)) throw "can't add a null object as a test case";
@@ -260,7 +270,11 @@ class Runner {
 
   function runFixture(fixture : TestFixture):TestHandler<TestFixture> {
     // cast is required by C#
+    #if (haxe_ver >= "3.4.0")
     var handler = (fixture.isITest ? new ITestHandler(fixture) : new TestHandler(fixture));
+    #else
+    var handler = new TestHandler(cast fixture);
+    #end
     handler.onComplete.add(testComplete);
     handler.onPrecheck.add(this.onPrecheck.dispatch);
     onTestStart.dispatch(handler);
@@ -275,7 +289,7 @@ class Runner {
   }
 }
 
-
+#if (haxe_ver >= "3.4.0")
 @:access(utest.Runner.iTestFixtures)
 @:access(utest.Runner.runNext)
 @:access(utest.Runner.runFixture)
@@ -377,3 +391,4 @@ private class ITestRunner {
     });
   }
 }
+#end

--- a/src/utest/Runner.hx
+++ b/src/utest/Runner.hx
@@ -223,6 +223,7 @@ class Runner {
   public function addFixture(fixture : TestFixture) {
     fixtures.push(fixture);
     length++;
+    #if (haxe_ver >= "3.4.0")
     if(fixture.isITest) {
       var testCase:ITest = cast fixture.target;
       var fixtures = iTestFixtures.get(testCase);
@@ -232,6 +233,7 @@ class Runner {
       }
       fixtures.push(fixture);
     }
+    #end
   }
 
   public function getFixture(index : Int) {
@@ -248,8 +250,12 @@ class Runner {
 
   public function run() {
     onStart.dispatch(this);
+    #if (haxe_ver >= "3.4.0")
     var iTestRunner = new ITestRunner(this);
     iTestRunner.run();
+    #else
+    runNext();
+    #end
   }
 
   var pos:Int = 0;

--- a/src/utest/Runner.hx
+++ b/src/utest/Runner.hx
@@ -125,7 +125,7 @@ class Runner {
     }
     var tests:Array<TestData> = (testCase:Dynamic).__initializeUtest__();
     for(test in tests) {
-      if(!isTestFixtureName(test.name, 'test', pattern, globalPattern)) {
+      if(!isTestFixtureName(test.name, ['test', 'spec'], pattern, globalPattern)) {
         continue;
       }
       addFixture(TestFixture.ofData(testCase, test));
@@ -145,7 +145,7 @@ class Runner {
     var fields = Type.getInstanceFields(Type.getClass(test));
       for (field in fields) {
         if(!isMethod(test, field)) continue;
-        if(!isTestFixtureName(field, prefix, pattern, globalPattern)) continue;
+        if(!isTestFixtureName(field, [prefix], pattern, globalPattern)) continue;
         addFixture(new TestFixture(test, field, setup, teardown, setupAsync, teardownAsync));
       }
   }
@@ -197,9 +197,14 @@ class Runner {
     return macro @:pos(pos) $b{exprs};
   }
 
-  private function isTestFixtureName(name:String, prefix:String, ?pattern:EReg, ?globalPattern:EReg):Bool {
+  private function isTestFixtureName(name:String, prefixes:Array<String>, ?pattern:EReg, ?globalPattern:EReg):Bool {
     if (pattern == null && globalPattern == null) {
-      return StringTools.startsWith(name, prefix);
+      for(prefix in prefixes) {
+        if(StringTools.startsWith(name, prefix)) {
+          return true;
+        }
+      }
+      return false;
     }
     if (pattern == null) pattern = globalPattern;
     return pattern.match(name);

--- a/src/utest/Runner.hx
+++ b/src/utest/Runner.hx
@@ -14,6 +14,7 @@ using haxe.macro.Tools;
 
 #if (haxe_ver >= "3.4.0")
 using utest.utils.AsyncUtils;
+using utest.utils.AccessoriesUtils;
 #end
 
 /**
@@ -143,9 +144,9 @@ class Runner {
       fixtures.push(fixture);
     }
     iTestFixtures.set(testCase, {
-      setupClass:utest.utils.AccessoriesUtils.getSetupClass(init.accessories),
+      setupClass:init.accessories.getSetupClass(),
       fixtures:fixtures,
-      teardownClass:utest.utils.AccessoriesUtils.getTeardownClass(init.accessories)
+      teardownClass:init.accessories.getTeardownClass()
     });
   }
   #end

--- a/src/utest/Test.hx
+++ b/src/utest/Test.hx
@@ -1,34 +1,8 @@
 package utest;
 
+/**
+ * Base test class for convenience.
+ */
 class Test implements ITest {
-
 	public function new() {}
-
-	/**
-	 * This method is executed once before running the first test in the current class
-	 */
-	public function setupClass():Null<Async> {
-		return Async.getResolved();
-	}
-
-	/**
-	 * This method is executed before each test.
-	 */
-	public function setup():Null<Async> {
-		return Async.getResolved();
-	}
-
-	/**
-	 * This method is executed after each test.
-	 */
-	public function teardown():Null<Async> {
-		return Async.getResolved();
-	}
-
-	/**
-	 * This method is executed once after the last test in the current class is finished.
-	 */
-	public function teardownClass():Null<Async> {
-		return Async.getResolved();
-	}
 }

--- a/src/utest/Test.hx
+++ b/src/utest/Test.hx
@@ -1,0 +1,34 @@
+package utest;
+
+class Test implements ITest {
+
+	public function new() {}
+
+	/**
+	 * This method is executed once before running the first test in the current class
+	 */
+	public function setupClass():Null<Async> {
+		return Async.getResolved();
+	}
+
+	/**
+	 * This method is executed before each test.
+	 */
+	public function setup():Null<Async> {
+		return Async.getResolved();
+	}
+
+	/**
+	 * This method is executed after each test.
+	 */
+	public function teardown():Null<Async> {
+		return Async.getResolved();
+	}
+
+	/**
+	 * This method is executed once after the last test in the current class is finished.
+	 */
+	public function teardownClass():Null<Async> {
+		return Async.getResolved();
+	}
+}

--- a/src/utest/TestData.hx
+++ b/src/utest/TestData.hx
@@ -8,3 +8,42 @@ typedef TestData = {
 	var execute(default,null):Void->Void;
 	@:optional var async(default,null):Async;
 }
+
+/**
+ * The data of accessory methods: setup, setupClass, teardown, teardownClass
+ */
+typedef Accessories = {
+	?setup:Accessory,
+	?setupClass:Accessory,
+	?teardown:Accessory,
+	?teardownClass:Accessory,
+}
+
+typedef Accessory = {
+	?method:Void->Void,
+	?asyncMethod:Void->Async
+}
+
+typedef InitializeUtest = {
+	accessories:Accessories,
+	tests:Array<TestData>
+}
+
+class AccessoryName {
+	/**
+	 * This method is executed once before running the first test in the current class
+	 */
+	static public inline var SETUP_NAME = 'setup';
+	/**
+	 * This method is executed before each test.
+	 */
+	static public inline var SETUP_CLASS_NAME = 'setupClass';
+	/**
+	 * This method is executed after each test.
+	 */
+	static public inline var TEARDOWN_NAME = 'teardown';
+	/**
+	 * This method is executed once after the last test in the current class is finished.
+	 */
+	static public inline var TEARDOWN_CLASS_NAME = 'teardownClass';
+}

--- a/src/utest/TestData.hx
+++ b/src/utest/TestData.hx
@@ -5,23 +5,17 @@ package utest;
  */
 typedef TestData = {
 	var name(default,null):String;
-	var execute(default,null):Void->Void;
-	@:optional var async(default,null):Async;
+	var execute(default,null):Void->Async;
 }
 
 /**
  * The data of accessory methods: setup, setupClass, teardown, teardownClass
  */
 typedef Accessories = {
-	?setup:Accessory,
-	?setupClass:Accessory,
-	?teardown:Accessory,
-	?teardownClass:Accessory,
-}
-
-typedef Accessory = {
-	?method:Void->Void,
-	?asyncMethod:Void->Async
+	?setup:Void->Async,
+	?setupClass:Void->Async,
+	?teardown:Void->Async,
+	?teardownClass:Void->Async,
 }
 
 typedef InitializeUtest = {

--- a/src/utest/TestData.hx
+++ b/src/utest/TestData.hx
@@ -1,0 +1,10 @@
+package utest;
+
+/**
+ * The data of a test as collected by utest.utils.TestBuilder at compile time.
+ */
+typedef TestData = {
+	var name(default,null):String;
+	var execute(default,null):Void->Void;
+	@:optional var async(default,null):Async;
+}

--- a/src/utest/TestFixture.hx
+++ b/src/utest/TestFixture.hx
@@ -13,9 +13,10 @@ class TestFixture {
   public var ignoringInfo(default, null)       : IgnoredFixture;
 
   @:allow(utest)
-  var test:Null<TestData>;
-  @:allow(utest)
   var isITest:Bool = false;
+  #if (haxe_ver >= "3.4.0")
+  @:allow(utest)
+  var test:Null<TestData>;
 
   static public function ofData(target:ITest, test:TestData):TestFixture {
     var fixture = new TestFixture(target, test.name);
@@ -23,6 +24,7 @@ class TestFixture {
     fixture.test = test;
     return fixture;
   }
+  #end
 
   public function new(target : {}, method : String, ?setup : String, ?teardown : String, ?setupAsync : String, ?teardownAsync : String) {
     this.target        = target;

--- a/src/utest/TestFixture.hx
+++ b/src/utest/TestFixture.hx
@@ -12,6 +12,18 @@ class TestFixture {
   public var teardownAsync(default, null) : String;
   public var ignoringInfo(default, null)       : IgnoredFixture;
 
+  @:allow(utest)
+  var test:Null<TestData>;
+  @:allow(utest)
+  var isITest:Bool = false;
+
+  static public function ofData(target:ITest, test:TestData):TestFixture {
+    var fixture = new TestFixture(target, test.name);
+    fixture.isITest = true;
+    fixture.test = test;
+    return fixture;
+  }
+
   public function new(target : {}, method : String, ?setup : String, ?teardown : String, ?setupAsync : String, ?teardownAsync : String) {
     this.target        = target;
     this.method        = method;

--- a/src/utest/TestFixture.hx
+++ b/src/utest/TestFixture.hx
@@ -17,11 +17,17 @@ class TestFixture {
   #if (haxe_ver >= "3.4.0")
   @:allow(utest)
   var test:Null<TestData>;
+  @:allow(utest)
+  var setupMethod:Void->Async;
+  @:allow(utest)
+  var teardownMethod:Void->Async;
 
-  static public function ofData(target:ITest, test:TestData):TestFixture {
+  static public function ofData(target:ITest, test:TestData, accessories:TestData.Accessories):TestFixture {
     var fixture = new TestFixture(target, test.name);
     fixture.isITest = true;
     fixture.test = test;
+    fixture.setupMethod = utest.utils.AccessoriesUtils.getSetup(accessories);
+    fixture.teardownMethod = utest.utils.AccessoriesUtils.getTeardown(accessories);
     return fixture;
   }
   #end

--- a/src/utest/TestHandler.hx
+++ b/src/utest/TestHandler.hx
@@ -107,8 +107,8 @@ class TestHandler<T> {
 
   public var expiration(default, null) : Null<Float>;
   public function setTimeout(timeout : Int) {
-    var newexpire = haxe.Timer.stamp() + timeout/1000;
-    expiration = (expiration == null) ? newexpire : (newexpire > expiration ? newexpire : expiration);
+    var newExpire = haxe.Timer.stamp() + timeout/1000;
+    expiration = (expiration == null) ? newExpire : (newExpire > expiration ? newExpire : expiration);
   }
 
   function bindHandler() {

--- a/src/utest/TestResult.hx
+++ b/src/utest/TestResult.hx
@@ -28,6 +28,7 @@ class TestResult {
     return r;
   }
 
+  #if (haxe_ver >= "3.4.0")
   public static function ofFailedSetupClass(testCase:ITest, assertation:Assertation):TestResult {
     var r = new TestResult();
     var path = Type.getClassName(Type.getClass(testCase)).split('.');
@@ -49,6 +50,7 @@ class TestResult {
     r.assertations.add(assertation);
     return r;
   }
+  #end
 
   public function allOk():Bool{
     for(l in assertations) {

--- a/src/utest/TestResult.hx
+++ b/src/utest/TestResult.hx
@@ -28,6 +28,28 @@ class TestResult {
     return r;
   }
 
+  public static function ofFailedSetupClass(testCase:ITest, assertation:Assertation):TestResult {
+    var r = new TestResult();
+    var path = Type.getClassName(Type.getClass(testCase)).split('.');
+    r.cls           = path.pop();
+    r.pack          = path.join('.');
+    r.method        = 'setup';
+    r.assertations  = new List();
+    r.assertations.add(assertation);
+    return r;
+  }
+
+  public static function ofFailedTeardownClass(testCase:ITest, assertation:Assertation):TestResult {
+    var r = new TestResult();
+    var path = Type.getClassName(Type.getClass(testCase)).split('.');
+    r.cls           = path.pop();
+    r.pack          = path.join('.');
+    r.method        = 'setup';
+    r.assertations  = new List();
+    r.assertations.add(assertation);
+    return r;
+  }
+
   public function allOk():Bool{
     for(l in assertations) {
       switch (l){

--- a/src/utest/ui/common/ResultAggregator.hx
+++ b/src/utest/ui/common/ResultAggregator.hx
@@ -44,13 +44,15 @@ class ResultAggregator {
         }
       }
     }
-    var baseMsg = 'implement utest.ITest. Non-ITest tests are deprecated. Implement utest.ITest or extend utest.Test.';
-    var msg = switch(total) {
-      case 0: '$first doesn\'t $baseMsg';
-      case 1: '$first and 1 other don\'t $baseMsg';
-      case _: '$first and $total others don\'t $baseMsg';
+    if(total > 0) {
+      var baseMsg = 'implement utest.ITest. Non-ITest tests are deprecated. Implement utest.ITest or extend utest.Test.';
+      var msg = switch(total) {
+        case 0: '$first doesn\'t $baseMsg';
+        case 1: '$first and 1 other don\'t $baseMsg';
+        case _: '$first and $total others don\'t $baseMsg';
+      }
+      trace(msg);
     }
-    trace(msg);
   }
 
   function getOrCreatePackage(pack : String, flat : Bool, ?ref : PackageResult) {

--- a/src/utest/ui/common/ResultAggregator.hx
+++ b/src/utest/ui/common/ResultAggregator.hx
@@ -27,8 +27,30 @@ class ResultAggregator {
   }
 
   function start(runner : Runner) {
+    checkNonITest();
     root = new PackageResult(null);
     onStart.dispatch();
+  }
+
+  function checkNonITest() {
+    var first = null;
+    var total = 0;
+    for(i in 0...runner.length) {
+      var fixture = runner.getFixture(i);
+      if(!fixture.isITest) {
+        total++;
+        if(first == null) {
+          first = Type.getClassName(Type.getClass(fixture.target));
+        }
+      }
+    }
+    var baseMsg = 'implement utest.ITest. Non-ITest tests are deprecated. Implement utest.ITest or extend utest.Test.';
+    var msg = switch(total) {
+      case 0: '$first doesn\'t $baseMsg';
+      case 1: '$first and 1 other don\'t $baseMsg';
+      case _: '$first and $total others don\'t $baseMsg';
+    }
+    trace(msg);
   }
 
   function getOrCreatePackage(pack : String, flat : Bool, ?ref : PackageResult) {

--- a/src/utest/utils/AccessoriesUtils.hx
+++ b/src/utest/utils/AccessoriesUtils.hx
@@ -2,60 +2,26 @@ package utest.utils;
 
 import utest.TestData;
 
+using utest.utils.AccessoriesUtils;
+
 class AccessoriesUtils {
 	static public function getSetupClass(accessories:Accessories):Void->Async {
-		if(accessories.setupClass != null) {
-			if(accessories.setupClass.method != null) {
-				return function() {
-					accessories.setupClass.method();
-					return Async.getResolved();
-				}
-			} else if(accessories.setupClass.asyncMethod != null) {
-				return accessories.setupClass.asyncMethod;
-			}
-		}
-		return Async.getResolved;
+		return accessories.setupClass.orStub();
 	}
 
 	static public function getSetup(accessories:Accessories):Void->Async {
-		if(accessories.setup != null) {
-			if(accessories.setup.method != null) {
-				return function() {
-					accessories.setup.method();
-					return Async.getResolved();
-				}
-			} else if(accessories.setup.asyncMethod != null) {
-				return accessories.setup.asyncMethod;
-			}
-		}
-		return Async.getResolved;
+		return accessories.setup.orStub();
 	}
 
 	static public function getTeardown(accessories:Accessories):Void->Async {
-		if(accessories.teardown != null) {
-			if(accessories.teardown.method != null) {
-				return function() {
-					accessories.teardown.method();
-					return Async.getResolved();
-				}
-			} else if(accessories.teardown.asyncMethod != null) {
-				return accessories.teardown.asyncMethod;
-			}
-		}
-		return Async.getResolved;
+		return accessories.teardown.orStub();
 	}
 
 	static public function getTeardownClass(accessories:Accessories):Void->Async {
-		if(accessories.teardownClass != null) {
-			if(accessories.teardownClass.method != null) {
-				return function() {
-					accessories.teardownClass.method();
-					return Async.getResolved();
-				}
-			} else if(accessories.teardownClass.asyncMethod != null) {
-				return accessories.teardownClass.asyncMethod;
-			}
-		}
-		return Async.getResolved;
+		return accessories.teardownClass.orStub();
+	}
+
+	static inline function orStub(fn:Null<Void->Async>):Void->Async {
+		return fn == null ? Async.getResolved : fn;
 	}
 }

--- a/src/utest/utils/AccessoriesUtils.hx
+++ b/src/utest/utils/AccessoriesUtils.hx
@@ -6,22 +6,18 @@ using utest.utils.AccessoriesUtils;
 
 class AccessoriesUtils {
 	static public function getSetupClass(accessories:Accessories):Void->Async {
-		return accessories.setupClass.orStub();
+		return accessories.setupClass == null ? Async.getResolved : accessories.setupClass;
 	}
 
 	static public function getSetup(accessories:Accessories):Void->Async {
-		return accessories.setup.orStub();
+		return accessories.setup == null ? Async.getResolved : accessories.setup;
 	}
 
 	static public function getTeardown(accessories:Accessories):Void->Async {
-		return accessories.teardown.orStub();
+		return accessories.teardown == null ? Async.getResolved : accessories.teardown;
 	}
 
 	static public function getTeardownClass(accessories:Accessories):Void->Async {
-		return accessories.teardownClass.orStub();
-	}
-
-	static inline function orStub(fn:Null<Void->Async>):Void->Async {
-		return fn == null ? Async.getResolved : fn;
+		return accessories.teardownClass == null ? Async.getResolved : accessories.teardownClass;
 	}
 }

--- a/src/utest/utils/AccessoriesUtils.hx
+++ b/src/utest/utils/AccessoriesUtils.hx
@@ -1,0 +1,61 @@
+package utest.utils;
+
+import utest.TestData;
+
+class AccessoriesUtils {
+	static public function getSetupClass(accessories:Accessories):Void->Async {
+		if(accessories.setupClass != null) {
+			if(accessories.setupClass.method != null) {
+				return function() {
+					accessories.setupClass.method();
+					return Async.getResolved();
+				}
+			} else if(accessories.setupClass.asyncMethod != null) {
+				return accessories.setupClass.asyncMethod;
+			}
+		}
+		return Async.getResolved;
+	}
+
+	static public function getSetup(accessories:Accessories):Void->Async {
+		if(accessories.setup != null) {
+			if(accessories.setup.method != null) {
+				return function() {
+					accessories.setup.method();
+					return Async.getResolved();
+				}
+			} else if(accessories.setup.asyncMethod != null) {
+				return accessories.setup.asyncMethod;
+			}
+		}
+		return Async.getResolved;
+	}
+
+	static public function getTeardown(accessories:Accessories):Void->Async {
+		if(accessories.teardown != null) {
+			if(accessories.teardown.method != null) {
+				return function() {
+					accessories.teardown.method();
+					return Async.getResolved();
+				}
+			} else if(accessories.teardown.asyncMethod != null) {
+				return accessories.teardown.asyncMethod;
+			}
+		}
+		return Async.getResolved;
+	}
+
+	static public function getTeardownClass(accessories:Accessories):Void->Async {
+		if(accessories.teardownClass != null) {
+			if(accessories.teardownClass.method != null) {
+				return function() {
+					accessories.teardownClass.method();
+					return Async.getResolved();
+				}
+			} else if(accessories.teardownClass.asyncMethod != null) {
+				return accessories.teardownClass.asyncMethod;
+			}
+		}
+		return Async.getResolved;
+	}
+}

--- a/src/utest/utils/AsyncUtils.hx
+++ b/src/utest/utils/AsyncUtils.hx
@@ -1,0 +1,7 @@
+package utest.utils;
+
+class AsyncUtils {
+	static public inline function orResolved(async:Null<Async>):Async {
+		return async == null ? Async.getResolved() : async;
+	}
+}

--- a/src/utest/utils/Macro.hx
+++ b/src/utest/utils/Macro.hx
@@ -1,0 +1,12 @@
+package utest.utils;
+
+import haxe.macro.Context;
+
+class Macro {
+	macro static public function checkHaxe() {
+		#if (haxe_ver < '3.4.0')
+		Context.warning('UTest will stop supporting Haxe 3.3 and older in UTest 2.0.0', Context.currentPos());
+		#end
+		return macro {}
+	}
+}

--- a/src/utest/utils/TestBuilder.hx
+++ b/src/utest/utils/TestBuilder.hx
@@ -3,9 +3,11 @@ package utest.utils;
 import haxe.macro.Type.ClassType;
 import haxe.macro.Context;
 import haxe.macro.Expr;
+import haxe.macro.ExprTools;
 
 class TestBuilder {
 	static inline var TEST_PREFIX = 'test';
+	static inline var SPEC_PREFIX = 'spec';
 	static inline var META_PROCESSED = ':utestProcessed';
 
 	macro static public function build():Array<Field> {
@@ -21,7 +23,7 @@ class TestBuilder {
 		var initExprs = [];
 		var fields = Context.getBuildFields();
 		for (field in fields) {
-			if(field.name.indexOf(TEST_PREFIX) != 0) {
+			if(!isTestName(field.name)) {
 				continue;
 			}
 			switch (field.kind) {
@@ -49,6 +51,10 @@ class TestBuilder {
 						case _:
 							Context.error('Wrong arguments count. The only supported argument is utest.Async for asynchronous tests.', field.pos);
 					}
+					//specification test
+					if(field.name.indexOf(SPEC_PREFIX) == 0 && fn.expr != null) {
+						fn.expr = prepareSpec(fn.expr);
+					}
 				case _:
 			}
 		}
@@ -75,6 +81,10 @@ class TestBuilder {
 		return fields;
 	}
 
+	static function isTestName(name:String):Bool {
+		return name.indexOf(TEST_PREFIX) == 0 || name.indexOf(SPEC_PREFIX) == 0;
+	}
+
 	static function ancestorHasInitializeUtest(cls:ClassType):Bool {
 		if(cls.superClass == null) {
 			return false;
@@ -86,5 +96,39 @@ class TestBuilder {
 			}
 		}
 		return ancestorHasInitializeUtest(superClass);
+	}
+
+	static function prepareSpec(expr:Expr) {
+		return switch(expr.expr) {
+			case EBlock(exprs):
+				var newExprs = [];
+				for(expr in exprs) {
+					if(isSpecOp(expr)) {
+						newExprs.push(macro @:pos(expr.pos) utest.Assert.isTrue($expr));
+					} else {
+						newExprs.push(ExprTools.map(expr, prepareSpec));
+					}
+				}
+				{expr:EBlock(newExprs), pos:expr.pos};
+			case _:
+				ExprTools.map(expr, prepareSpec);
+		}
+	}
+
+	static function isSpecOp(expr:Expr):Bool {
+		return switch(expr.expr) {
+			case EBinop(op,	_, _):
+				switch(op) {
+					case OpEq | OpNotEq | OpGt | OpGte | OpLt | OpLte: true;
+					case _: false;
+				}
+			case EUnop(op, false, _):
+				switch (op) {
+					case OpNot: true;
+					case _: false;
+				}
+			case _:
+				false;
+		}
 	}
 }

--- a/src/utest/utils/TestBuilder.hx
+++ b/src/utest/utils/TestBuilder.hx
@@ -1,9 +1,17 @@
 package utest.utils;
 
+import utest.TestData.AccessoryName;
 import haxe.macro.Type.ClassType;
 import haxe.macro.Context;
 import haxe.macro.Expr;
 import haxe.macro.ExprTools;
+
+@:enum
+private abstract IsAsync(Int) {
+	var Yes = 1;
+	var No = 0;
+	var Unknown = -1;
+}
 
 class TestBuilder {
 	static inline var TEST_PREFIX = 'test';
@@ -20,55 +28,25 @@ class TestBuilder {
 
 		cls.meta.add(META_PROCESSED, [], cls.pos);
 
-		var initExprs = [];
+		var isOverriding = ancestorHasInitializeUtest(cls);
+		var initExprs = initialExpressions(isOverriding);
 		var fields = Context.getBuildFields();
 		for (field in fields) {
-			if(!isTestName(field.name)) {
-				continue;
-			}
 			switch (field.kind) {
 				case FFun(fn):
-					var test = field.name;
-					switch(fn.args.length) {
-						//synchronous test
-						case 0:
-							initExprs.push(macro @:pos(field.pos) executors.push({name:$v{test}, execute:this.$test}));
-						//asynchronous test
-						case 1:
-							initExprs.push(macro @:pos(field.pos) {
-								var async = new utest.Async();
-								@:privateAccess async.timer.stop();
-								executors.push({
-									name:$v{test},
-									async:async,
-									execute:function() {
-										@:privateAccess async.start(250);
-										this.$test(async);
-									}
-								});
-							});
-						//wtf test
-						case _:
-							Context.error('Wrong arguments count. The only supported argument is utest.Async for asynchronous tests.', field.pos);
-					}
-					//specification test
-					if(field.name.indexOf(SPEC_PREFIX) == 0 && fn.expr != null) {
-						fn.expr = prepareSpec(fn.expr);
+					if(isTestName(field.name)) {
+						processTest(field, fn, initExprs);
+					} else if(isAccessoryMethod(field.name)) {
+						processAccessory(field, fn, initExprs);
 					}
 				case _:
 			}
 		}
-		initExprs.push(macro return executors);
-
-		var isOverriding = ancestorHasInitializeUtest(cls);
-		if(isOverriding) {
-			initExprs.unshift(macro var executors = super.__initializeUtest__());
-		} else {
-			initExprs.unshift(macro var executors = new Array<utest.TestData>());
-		}
+		initExprs.push(macro return init);
 
 		var initialize = (macro class Dummy {
-			@:noCompletion function __initializeUtest__() $b{initExprs}
+			@:noCompletion function __initializeUtest__():utest.TestData.InitializeUtest
+				$b{initExprs}
 		}).fields[0];
 		if(isOverriding) {
 			if(initialize.access == null) {
@@ -81,8 +59,95 @@ class TestBuilder {
 		return fields;
 	}
 
+	static function initialExpressions(isOverriding:Bool):Array<Expr> {
+		var initExprs = [];
+
+		if(isOverriding) {
+			initExprs.push(macro var init = super.__initializeUtest__());
+		} else {
+			initExprs.push(macro var init:utest.TestData.InitializeUtest = {tests:[], accessories:{}});
+		}
+
+		return initExprs;
+	}
+
+	static function processTest(field:Field, fn:Function, initExprs:Array<Expr>) {
+		var test = field.name;
+		switch(fn.args.length) {
+			//synchronous test
+			case 0:
+				initExprs.push(macro @:pos(field.pos) init.tests.push({name:$v{test}, execute:this.$test}));
+			//asynchronous test
+			case 1:
+				initExprs.push(macro @:pos(field.pos) {
+					var async = new utest.Async();
+					@:privateAccess async.timer.stop();
+					init.tests.push({
+						name:$v{test},
+						async:async,
+						execute:function() {
+							@:privateAccess async.start(250);
+							this.$test(async);
+						}
+					});
+				});
+			//wtf test
+			case _:
+				Context.error('Wrong arguments count. The only supported argument is utest.Async for asynchronous tests.', field.pos);
+		}
+		//specification test
+		if(field.name.indexOf(SPEC_PREFIX) == 0 && fn.expr != null) {
+			fn.expr = prepareSpec(fn.expr);
+		}
+	}
+
+	/**
+	 * setup, setupClass, teardown, teardownClass
+	 */
+	static function processAccessory(field:Field, fn:Function, initExprs:Array<Expr>) {
+		var name = field.name;
+		var isAsync = switch(fn.ret) {
+			case null: isAsyncFunctionBody(fn.expr);
+			case macro:Void: false;
+			case _: isAsyncFunctionBody(fn.expr);
+		}
+		var cfgFieldName = isAsync ? 'asyncMethod' : 'method';
+		initExprs.push(macro @:pos(field.pos) init.accessories.$name = {$cfgFieldName:$i{name}});
+	}
+
+	static function isAsyncFunctionBody(expr:Expr):Bool {
+		var isAsync = Unknown;
+		function traverse(expr:Expr) {
+			if(isAsync != Unknown) return;
+			switch(expr.expr) {
+				case EReturn(null):
+					isAsync = No;
+				case EReturn(_):
+					isAsync = Yes;
+				case EFunction(_, _):
+				case _:
+					ExprTools.iter(expr, traverse);
+			}
+		}
+		traverse(expr);
+		return switch(isAsync) {
+			case No | Unknown: false;
+			case Yes: true;
+		}
+	}
+
 	static function isTestName(name:String):Bool {
 		return name.indexOf(TEST_PREFIX) == 0 || name.indexOf(SPEC_PREFIX) == 0;
+	}
+
+	static function isAccessoryMethod(name:String):Bool {
+		return switch(name) {
+			case AccessoryName.SETUP_NAME: true;
+			case AccessoryName.SETUP_CLASS_NAME: true;
+			case AccessoryName.TEARDOWN_NAME: true;
+			case AccessoryName.TEARDOWN_CLASS_NAME: true;
+			case _: false;
+		}
 	}
 
 	static function ancestorHasInitializeUtest(cls:ClassType):Bool {

--- a/src/utest/utils/TestBuilder.hx
+++ b/src/utest/utils/TestBuilder.hx
@@ -38,6 +38,8 @@ class TestBuilder {
 						processTest(field, fn, initExprs);
 					} else if(isAccessoryMethod(field.name)) {
 						processAccessory(field, fn, initExprs);
+					} else {
+						checkPossibleTypo(field);
 					}
 				case _:
 			}
@@ -194,6 +196,22 @@ class TestBuilder {
 				}
 			case _:
 				false;
+		}
+	}
+
+	static var names = [
+		AccessoryName.SETUP_CLASS_NAME,
+		AccessoryName.SETUP_NAME,
+		AccessoryName.TEARDOWN_CLASS_NAME,
+		AccessoryName.TEARDOWN_NAME
+	];
+	static function checkPossibleTypo(field:Field) {
+		var pos = Context.currentPos();
+		var lowercasedName = field.name.toLowerCase();
+		for(name in names) {
+			if(lowercasedName == name.toLowerCase()) {
+				Context.warning('Did you mean "$name"?', pos);
+			}
 		}
 	}
 }

--- a/src/utest/utils/TestBuilder.hx
+++ b/src/utest/utils/TestBuilder.hx
@@ -1,0 +1,90 @@
+package utest.utils;
+
+import haxe.macro.Type.ClassType;
+import haxe.macro.Context;
+import haxe.macro.Expr;
+
+class TestBuilder {
+	static inline var TEST_PREFIX = 'test';
+	static inline var META_PROCESSED = ':utestProcessed';
+
+	macro static public function build():Array<Field> {
+		if(Context.defined('display') #if display || true #end) {
+			return null;
+		}
+
+		var cls = Context.getLocalClass().get();
+		if (cls.isInterface || cls.meta.has(META_PROCESSED)) return null;
+
+		cls.meta.add(META_PROCESSED, [], cls.pos);
+
+		var initExprs = [];
+		var fields = Context.getBuildFields();
+		for (field in fields) {
+			if(field.name.indexOf(TEST_PREFIX) != 0) {
+				continue;
+			}
+			switch (field.kind) {
+				case FFun(fn):
+					var test = field.name;
+					switch(fn.args.length) {
+						//synchronous test
+						case 0:
+							initExprs.push(macro @:pos(field.pos) executors.push({name:$v{test}, execute:this.$test}));
+						//asynchronous test
+						case 1:
+							initExprs.push(macro @:pos(field.pos) {
+								var async = new utest.Async();
+								@:privateAccess async.timer.stop();
+								executors.push({
+									name:$v{test},
+									async:async,
+									execute:function() {
+										@:privateAccess async.start(250);
+										this.$test(async);
+									}
+								});
+							});
+						//wtf test
+						case _:
+							Context.error('Wrong arguments count. The only supported argument is utest.Async for asynchronous tests.', field.pos);
+					}
+				case _:
+			}
+		}
+		initExprs.push(macro return executors);
+
+		var isOverriding = ancestorHasInitializeUtest(cls);
+		if(isOverriding) {
+			initExprs.unshift(macro var executors = super.__initializeUtest__());
+		} else {
+			initExprs.unshift(macro var executors = new Array<utest.TestData>());
+		}
+
+		var initialize = (macro class Dummy {
+			@:noCompletion function __initializeUtest__() $b{initExprs}
+		}).fields[0];
+		if(isOverriding) {
+			if(initialize.access == null) {
+				initialize.access = [];
+			}
+			initialize.access.push(AOverride);
+		}
+
+		fields.push(initialize);
+		return fields;
+	}
+
+	static function ancestorHasInitializeUtest(cls:ClassType):Bool {
+		if(cls.superClass == null) {
+			return false;
+		}
+		var superClass = cls.superClass.t.get();
+		for(field in superClass.fields.get()) {
+			if(field.name == '__initializeUtest__') {
+				return true;
+			}
+		}
+		return ancestorHasInitializeUtest(superClass);
+	}
+}

--- a/test/TestAll.hx
+++ b/test/TestAll.hx
@@ -4,17 +4,19 @@ import utest.ui.Report;
 import utest.TestResult;
 
 class TestAll {
+  #if (haxe_ver >= "3.4.0")
   static var testITest:TestITest = new TestITest();
+  #end
 
   public static function addTests(runner : Runner) {
     runner.addCase(new utest.TestAssert());
     runner.addCase(new utest.TestDispatcher());
     #if (haxe_ver >= "3.4.0")
     runner.addCase(new utest.TestAsync());
+    runner.addCase(testITest);
     #end
     runner.addCase(new utest.TestIgnored());
     runner.addCase(new utest.TestRunner());
-    runner.addCase(testITest);
   }
 
   public static function main() {
@@ -27,11 +29,13 @@ class TestAll {
     // get test result to determine exit status
     var r:TestResult = null;
     runner.onProgress.add(function(o){ if (o.done == o.totals) r = o.result;});
+    #if (haxe_ver >= "3.4.0")
     runner.onComplete.add(function(runner) {
       if(testITest.teardownClassRunning) {
         throw 'TestITest: missed teardownClass() async completion.';
       }
     });
+    #end
     runner.run();
   }
 

--- a/test/TestAll.hx
+++ b/test/TestAll.hx
@@ -1,10 +1,12 @@
-﻿import utest.Runner;
+﻿import utest.TestITest;
+import utest.Runner;
 import utest.ui.Report;
 import utest.TestResult;
 
 class TestAll {
+  static var testITest:TestITest = new TestITest();
+
   public static function addTests(runner : Runner) {
-    //runner.globalPattern = ~/testBooleans/;
     runner.addCase(new utest.TestAssert());
     runner.addCase(new utest.TestDispatcher());
     #if (haxe_ver >= "3.4.0")
@@ -12,6 +14,7 @@ class TestAll {
     #end
     runner.addCase(new utest.TestIgnored());
     runner.addCase(new utest.TestRunner());
+    runner.addCase(testITest);
   }
 
   public static function main() {
@@ -24,6 +27,11 @@ class TestAll {
     // get test result to determine exit status
     var r:TestResult = null;
     runner.onProgress.add(function(o){ if (o.done == o.totals) r = o.result;});
+    runner.onComplete.add(function(runner) {
+      if(testITest.teardownClassRunning) {
+        throw 'TestITest: missed teardownClass() async completion.';
+      }
+    });
     runner.run();
   }
 

--- a/test/TestAll.hx
+++ b/test/TestAll.hx
@@ -1,7 +1,9 @@
-﻿import utest.TestITest;
-import utest.Runner;
+﻿import utest.Runner;
 import utest.ui.Report;
 import utest.TestResult;
+#if (haxe_ver >= "3.4.0")
+import utest.TestITest;
+#end
 
 class TestAll {
   #if (haxe_ver >= "3.4.0")

--- a/test/TestAll.hx
+++ b/test/TestAll.hx
@@ -2,12 +2,12 @@
 import utest.ui.Report;
 import utest.TestResult;
 #if (haxe_ver >= "3.4.0")
-import utest.TestITest;
+import utest.TestAsyncITest;
 #end
 
 class TestAll {
   #if (haxe_ver >= "3.4.0")
-  static var testITest:TestITest = new TestITest();
+  static var testAsyncITest:TestAsyncITest = new TestAsyncITest();
   #end
 
   public static function addTests(runner : Runner) {
@@ -15,7 +15,9 @@ class TestAll {
     runner.addCase(new utest.TestDispatcher());
     #if (haxe_ver >= "3.4.0")
     runner.addCase(new utest.TestAsync());
-    runner.addCase(testITest);
+    runner.addCase(new utest.TestSyncITest());
+    runner.addCase(new utest.TestSpec());
+    runner.addCase(testAsyncITest);
     #end
     runner.addCase(new utest.TestIgnored());
     runner.addCase(new utest.TestRunner());
@@ -33,8 +35,8 @@ class TestAll {
     runner.onProgress.add(function(o){ if (o.done == o.totals) r = o.result;});
     #if (haxe_ver >= "3.4.0")
     runner.onComplete.add(function(runner) {
-      if(testITest.teardownClassRunning) {
-        throw 'TestITest: missed teardownClass() async completion.';
+      if(testAsyncITest.teardownClassRunning) {
+        throw 'TestAsyncITest: missed teardownClass() async completion.';
       }
     });
     #end

--- a/test/utest/TestAssert.hx
+++ b/test/utest/TestAssert.hx
@@ -315,6 +315,11 @@ class TestAssert {
     expect(0, 0, 1);
   }
 
+  public function testCreateAsync() {
+    var assert = Assert.createAsync(function() Assert.pass(), 100);
+    haxe.Timer.delay(assert, 50);
+  }
+
   public function expect(esuccesses : Int, efailures : Int, eothers = 0) {
     var successes = 0;
     var failures  = 0;

--- a/test/utest/TestAssert.hx
+++ b/test/utest/TestAssert.hx
@@ -315,10 +315,12 @@ class TestAssert {
     expect(0, 0, 1);
   }
 
+  #if (haxe_ver >= "3.4.0")
   public function testCreateAsync() {
     var assert = Assert.createAsync(function() Assert.pass(), 100);
     haxe.Timer.delay(assert, 50);
   }
+  #end
 
   public function expect(esuccesses : Int, efailures : Int, eothers = 0) {
     var successes = 0;

--- a/test/utest/TestAsync.hx
+++ b/test/utest/TestAsync.hx
@@ -1,10 +1,19 @@
 package utest;
 
-class TestAsync {
-  public function new() {}
+class TestAsync extends Test {
+	public function testResolved() {
+		var async = Async.getResolved();
+		Assert.isTrue(async.resolved);
+	}
 
-  public function testCreateAsync() {
-    var assert = Assert.createAsync(function() Assert.pass(), 100);
-    haxe.Timer.delay(assert, 50);
-  }
+	public function testDone() {
+		var async = new Async();
+		async.then(function() Assert.pass());
+		async.done();
+	}
+
+	public function testDone_resolved() {
+		var async = Async.getResolved();
+		async.then(function() Assert.pass());
+	}
 }

--- a/test/utest/TestAsync.hx
+++ b/test/utest/TestAsync.hx
@@ -1,18 +1,18 @@
 package utest;
 
 class TestAsync extends Test {
-	public function testResolved() {
+	function testResolved() {
 		var async = Async.getResolved();
 		Assert.isTrue(async.resolved);
 	}
 
-	public function testDone() {
+	function testDone() {
 		var async = new Async();
 		async.then(function() Assert.pass());
 		async.done();
 	}
 
-	public function testDone_resolved() {
+	function testDone_resolved() {
 		var async = Async.getResolved();
 		async.then(function() Assert.pass());
 	}

--- a/test/utest/TestAsyncITest.hx
+++ b/test/utest/TestAsyncITest.hx
@@ -2,7 +2,7 @@ package utest;
 
 import haxe.Timer;
 
-class TestITest extends Test {
+class TestAsyncITest extends Test {
 	var setupClassCallCount = 0;
 	var setupCallCount = 0;
 	var teardownCallCount = 0;
@@ -12,7 +12,7 @@ class TestITest extends Test {
 	var teardownRunning:Bool = false;
 	public var teardownClassRunning(default,null):Bool = false;
 
-	override function setupClass():Null<Async> {
+	function setupClass():Async {
 		setupClassRunning = true;
 		setupClassCallCount++;
 		var async = new Async();
@@ -25,14 +25,14 @@ class TestITest extends Test {
 		return async;
 	}
 
-	override function setup():Null<Async> {
+	function setup():Async {
 		setupRunning = true;
 
 		if(setupClassRunning) {
-			throw 'TestITest: setup() called before setupClass() finished.';
+			throw 'TestAsyncITest: setup() called before setupClass() finished.';
 		}
 		if(teardownRunning) {
-			throw 'TestITest: setup() called before teardown() finished.';
+			throw 'TestAsyncITest: setup() called before teardown() finished.';
 		}
 
 		setupCallCount++;
@@ -49,10 +49,10 @@ class TestITest extends Test {
 	function testAsync(async:Async) {
 		var tm = Timer.stamp();
 		if(setupRunning) {
-			throw 'TestITest: test run before setup() finished.';
+			throw 'TestAsyncITest: test run before setup() finished.';
 		}
 		if(teardownRunning) {
-			throw 'TestITest: setup() called before teardown() finished.';
+			throw 'TestAsyncITest: setup() called before teardown() finished.';
 		}
 
 		var setupClassCallCount = setupClassCallCount;
@@ -67,36 +67,23 @@ class TestITest extends Test {
 		);
 	}
 
-	function specTest() {
-		Std.random(1) == 0;
-		Std.random(1) != 1;
-		Std.random(1) + 1 > 0;
-		Std.random(1) + 1 >= 1;
-		Std.random(1) + 1 <= 1;
-		Std.random(1) + 1 < 2;
-		!(Std.random(1) == 1);
-		if(Std.random(1) == 0) {
-			Std.random(1) == 0;
-		}
-	}
-
 	function testNormal() {
 		if(setupRunning) {
-			throw 'TestITest: test run before setup() finished.';
+			throw 'TestAsyncITest: test run before setup() finished.';
 		}
 		if(teardownRunning) {
-			throw 'TestITest: setup() called before teardown() finished.';
+			throw 'TestAsyncITest: setup() called before teardown() finished.';
 		}
 
 		Assert.equals(1, setupClassCallCount);
 		Assert.isTrue(setupCallCount > 0);
 	}
 
-	override function teardown():Null<Async> {
+	function teardown():Async {
 		teardownRunning = true;
 
 		if(setupRunning) {
-			throw 'TestITest: teardown() called before setup() finished.';
+			throw 'TestAsyncITest: teardown() called before setup() finished.';
 		}
 
 		teardownCallCount++;
@@ -111,27 +98,27 @@ class TestITest extends Test {
 		return async;
 	}
 
-	override function teardownClass():Null<Async> {
+	function teardownClass():Async {
 		teardownClassRunning = true;
 
 		if(teardownRunning) {
-			throw 'TestITest: teardownClass() called before teardown() finished.';
+			throw 'TestAsyncITest: teardownClass() called before teardown() finished.';
 		}
 
 		teardownClassCallCount++;
 
 		if(setupClassCallCount != 1) {
-			throw 'TestITest: setupClassCallCount should be called one time. Actual: $setupClassCallCount.';
+			throw 'TestAsyncITest: setupClassCallCount should be called one time. Actual: $setupClassCallCount.';
 		}
-		var testCount = __initializeUtest__().length;
+		var testCount = #if display 0 #else  __initializeUtest__().tests.length #end;
 		if(setupCallCount != testCount) {
-			throw 'TestITest: setupCallCount should be called once per test. Expected: $testCount, actual: $setupCallCount.';
+			throw 'TestAsyncITest: setupCallCount should be called once per test. Expected: $testCount, actual: $setupCallCount.';
 		}
 		if(teardownCallCount != testCount) {
-			throw 'TestITest: teardownClassCallCount should be called once per test. Expected: $testCount, actual: $teardownCallCount.';
+			throw 'TestAsyncITest: teardownClassCallCount should be called once per test. Expected: $testCount, actual: $teardownCallCount.';
 		}
 		if(teardownClassCallCount != 1) {
-			throw 'TestITest: teardownClassCallCount should be called one time. Actual: $teardownClassCallCount.';
+			throw 'TestAsyncITest: teardownClassCallCount should be called one time. Actual: $teardownClassCallCount.';
 		}
 
 		var async = new Async(2000);

--- a/test/utest/TestAsyncITest.hx
+++ b/test/utest/TestAsyncITest.hx
@@ -12,20 +12,19 @@ class TestAsyncITest extends Test {
 	var teardownRunning:Bool = false;
 	public var teardownClassRunning(default,null):Bool = false;
 
-	function setupClass():Async {
+	function setupClass(async:Async) {
 		setupClassRunning = true;
 		setupClassCallCount++;
-		var async = new Async();
 		Timer.delay(
 			function() {
 				setupClassRunning = false;
 				async.done();
 			},
-			50);
-		return async;
+			50
+		);
 	}
 
-	function setup():Async {
+	function setup(async:Async) {
 		setupRunning = true;
 
 		if(setupClassRunning) {
@@ -36,14 +35,13 @@ class TestAsyncITest extends Test {
 		}
 
 		setupCallCount++;
-		var async = new Async();
 		Timer.delay(
 			function() {
 				setupRunning = false;
 				async.done();
 			},
-			50);
-		return async;
+			50
+		);
 	}
 
 	function testAsync(async:Async) {
@@ -79,7 +77,7 @@ class TestAsyncITest extends Test {
 		Assert.isTrue(setupCallCount > 0);
 	}
 
-	function teardown():Async {
+	function teardown(async:Async) {
 		teardownRunning = true;
 
 		if(setupRunning) {
@@ -88,17 +86,16 @@ class TestAsyncITest extends Test {
 
 		teardownCallCount++;
 		teardownRunning = false;
-		var async = new Async();
 		Timer.delay(
 			function() {
 				teardownRunning = false;
 				async.done();
 			},
-			50);
-		return async;
+			50
+		);
 	}
 
-	function teardownClass():Async {
+	function teardownClass(async:Async) {
 		teardownClassRunning = true;
 
 		if(teardownRunning) {
@@ -121,13 +118,13 @@ class TestAsyncITest extends Test {
 			throw 'TestAsyncITest: teardownClassCallCount should be called one time. Actual: $teardownClassCallCount.';
 		}
 
-		var async = new Async(2000);
+		async.setTimeout(2500);
 		Timer.delay(
 			function() {
 				teardownClassRunning = false;
 				async.done();
 			},
-			1750);
-		return async;
+			1750
+		);
 	}
 }

--- a/test/utest/TestITest.hx
+++ b/test/utest/TestITest.hx
@@ -46,7 +46,7 @@ class TestITest extends Test {
 		return async;
 	}
 
-	public function testAsync(async:Async) {
+	function testAsync(async:Async) {
 		var tm = Timer.stamp();
 		if(setupRunning) {
 			throw 'TestITest: test run before setup() finished.';
@@ -67,7 +67,7 @@ class TestITest extends Test {
 		);
 	}
 
-	public function specTest() {
+	function specTest() {
 		Std.random(1) == 0;
 		Std.random(1) != 1;
 		Std.random(1) + 1 > 0;
@@ -80,7 +80,7 @@ class TestITest extends Test {
 		}
 	}
 
-	public function testNormal() {
+	function testNormal() {
 		if(setupRunning) {
 			throw 'TestITest: test run before setup() finished.';
 		}

--- a/test/utest/TestITest.hx
+++ b/test/utest/TestITest.hx
@@ -1,0 +1,132 @@
+package utest;
+
+import haxe.Timer;
+
+class TestITest extends Test {
+	var setupClassCallCount = 0;
+	var setupCallCount = 0;
+	var teardownCallCount = 0;
+	var teardownClassCallCount = 0;
+	var setupClassRunning:Bool = false;
+	var setupRunning:Bool = false;
+	var teardownRunning:Bool = false;
+	public var teardownClassRunning(default,null):Bool = false;
+
+	override function setupClass():Null<Async> {
+		setupClassRunning = true;
+		setupClassCallCount++;
+		var async = new Async();
+		Timer.delay(
+			function() {
+				setupClassRunning = false;
+				async.done();
+			},
+			50);
+		return async;
+	}
+
+	override function setup():Null<Async> {
+		setupRunning = true;
+
+		if(setupClassRunning) {
+			throw 'TestITest: setup() called before setupClass() finished.';
+		}
+		if(teardownRunning) {
+			throw 'TestITest: setup() called before teardown() finished.';
+		}
+
+		setupCallCount++;
+		var async = new Async();
+		Timer.delay(
+			function() {
+				setupRunning = false;
+				async.done();
+			},
+			50);
+		return async;
+	}
+
+	public function testAsync(async:Async) {
+		var tm = Timer.stamp();
+		if(setupRunning) {
+			throw 'TestITest: test run before setup() finished.';
+		}
+		if(teardownRunning) {
+			throw 'TestITest: setup() called before teardown() finished.';
+		}
+
+		var setupClassCallCount = setupClassCallCount;
+		var setupCalled = setupCallCount > 0;
+		Timer.delay(
+			function() {
+				Assert.equals(1, setupClassCallCount);
+				Assert.isTrue(setupCalled);
+				async.done();
+			},
+			50
+		);
+	}
+
+	public function testNormal() {
+		if(setupRunning) {
+			throw 'TestITest: test run before setup() finished.';
+		}
+		if(teardownRunning) {
+			throw 'TestITest: setup() called before teardown() finished.';
+		}
+
+		Assert.equals(1, setupClassCallCount);
+		Assert.isTrue(setupCallCount > 0);
+	}
+
+	override function teardown():Null<Async> {
+		teardownRunning = true;
+
+		if(setupRunning) {
+			throw 'TestITest: teardown() called before setup() finished.';
+		}
+
+		teardownCallCount++;
+		teardownRunning = false;
+		var async = new Async();
+		Timer.delay(
+			function() {
+				teardownRunning = false;
+				async.done();
+			},
+			50);
+		return async;
+	}
+
+	override function teardownClass():Null<Async> {
+		teardownClassRunning = true;
+
+		if(teardownRunning) {
+			throw 'TestITest: teardownClass() called before teardown() finished.';
+		}
+
+		teardownClassCallCount++;
+
+		if(setupClassCallCount != 1) {
+			throw 'TestITest: setupClassCallCount should be called one time. Actual: $setupClassCallCount.';
+		}
+		if(setupCallCount != 2) {
+			throw 'TestITest: setupClassCallCount should be called once per test. Expected: 2, actual: $setupCallCount.';
+		}
+		if(teardownCallCount != 2) {
+			throw 'TestITest: teardownClassCallCount should be called once per test. Expected: 2, actual: $teardownCallCount.';
+		}
+		if(teardownClassCallCount != 1) {
+			throw 'TestITest: teardownClassCallCount should be called one time. Actual: $teardownClassCallCount.';
+		}
+
+		var async = new Async(5000);
+		Timer.delay(
+			function() {
+				teardownClassRunning = false;
+				async.done();
+			},
+			4500);
+		return async;
+	}
+}

--- a/test/utest/TestITest.hx
+++ b/test/utest/TestITest.hx
@@ -67,6 +67,19 @@ class TestITest extends Test {
 		);
 	}
 
+	public function specTest() {
+		Std.random(1) == 0;
+		Std.random(1) != 1;
+		Std.random(1) + 1 > 0;
+		Std.random(1) + 1 >= 1;
+		Std.random(1) + 1 <= 1;
+		Std.random(1) + 1 < 2;
+		!(Std.random(1) == 1);
+		if(Std.random(1) == 0) {
+			Std.random(1) == 0;
+		}
+	}
+
 	public function testNormal() {
 		if(setupRunning) {
 			throw 'TestITest: test run before setup() finished.';
@@ -110,23 +123,24 @@ class TestITest extends Test {
 		if(setupClassCallCount != 1) {
 			throw 'TestITest: setupClassCallCount should be called one time. Actual: $setupClassCallCount.';
 		}
-		if(setupCallCount != 2) {
-			throw 'TestITest: setupClassCallCount should be called once per test. Expected: 2, actual: $setupCallCount.';
+		var testCount = __initializeUtest__().length;
+		if(setupCallCount != testCount) {
+			throw 'TestITest: setupCallCount should be called once per test. Expected: $testCount, actual: $setupCallCount.';
 		}
-		if(teardownCallCount != 2) {
-			throw 'TestITest: teardownClassCallCount should be called once per test. Expected: 2, actual: $teardownCallCount.';
+		if(teardownCallCount != testCount) {
+			throw 'TestITest: teardownClassCallCount should be called once per test. Expected: $testCount, actual: $teardownCallCount.';
 		}
 		if(teardownClassCallCount != 1) {
 			throw 'TestITest: teardownClassCallCount should be called one time. Actual: $teardownClassCallCount.';
 		}
 
-		var async = new Async(5000);
+		var async = new Async(2000);
 		Timer.delay(
 			function() {
 				teardownClassRunning = false;
 				async.done();
 			},
-			4500);
+			1750);
 		return async;
 	}
 }

--- a/test/utest/TestSpec.hx
+++ b/test/utest/TestSpec.hx
@@ -1,0 +1,16 @@
+package utest;
+
+class TestSpec extends Test {
+	function specTest() {
+		Std.random(1) == 0;
+		Std.random(1) != 1;
+		Std.random(1) + 1 > 0;
+		Std.random(1) + 1 >= 1;
+		Std.random(1) + 1 <= 1;
+		Std.random(1) + 1 < 2;
+		!(Std.random(1) == 1);
+		if(Std.random(1) == 0) {
+			Std.random(1) == 0;
+		}
+	}
+}

--- a/test/utest/TestSyncITest.hx
+++ b/test/utest/TestSyncITest.hx
@@ -1,0 +1,48 @@
+package utest;
+
+class TestSyncITest extends Test {
+	var setupClassCallCount = 0;
+	var setupCallCount = 0;
+	var teardownCallCount = 0;
+	var teardownClassCallCount = 0;
+
+	function setupClass() {
+		setupClassCallCount++;
+	}
+
+	function setup() {
+		setupCallCount++;
+	}
+
+	function testSync1() {
+		Assert.equals(1, setupClassCallCount);
+		Assert.isTrue(setupCallCount > 0);
+	}
+
+	function testSync2() {
+		Assert.equals(1, setupClassCallCount);
+		Assert.isTrue(setupCallCount > 0);
+	}
+
+	function teardown() {
+		teardownCallCount++;
+	}
+
+	function teardownClass() {
+		teardownClassCallCount++;
+
+		if(setupClassCallCount != 1) {
+			throw 'TestSyncITest: setupClassCallCount should be called one time. Actual: $setupClassCallCount.';
+		}
+		var testCount = #if display 0 #else  __initializeUtest__().tests.length #end;
+		if(setupCallCount != testCount) {
+			throw 'TestSyncITest: setupCallCount should be called once per test. Expected: $testCount, actual: $setupCallCount.';
+		}
+		if(teardownCallCount != testCount) {
+			throw 'TestSyncITest: teardownClassCallCount should be called once per test. Expected: $testCount, actual: $teardownCallCount.';
+		}
+		if(teardownClassCallCount != 1) {
+			throw 'TestSyncITest: teardownClassCallCount should be called one time. Actual: $teardownClassCallCount.';
+		}
+	}
+}


### PR DESCRIPTION
This PR adds `utest.Test` and `utest.ITest`.
Test cases should extend or implement them. 
The old way of creating test cases is still supported, but emits deprecation notice at runtime.
Eventually this will become the requirement when 2.0.0 is released.
Closes #28, #14, #11.

Test case should follow some conventions:

  * Every test case method name must be prefixed with `test` or `spec`;
  * If a method is prefixed with `spec` it is treated as the specification test. Every boolean binary operation will be wrapped in `Assert.isTrue()`

To following methods could be implemented to setup or teardown:
```haxe
 /**
 * This method is executed once before running the first test in the current class.
 * If it accepts an argument, it is treated as an asynchronous method.
 */
function setupClass():Void;
function setupClass(async:Async):Void;
/**
 * This method is executed before each test.
  * If it accepts an argument, it is treated as an asynchronous method.
 */
function setup():Void;
function setup(async:Async):Void;
/**
 * This method is executed after each test.
  * If it accepts an argument, it is treated as an asynchronous method.
 */
function teardown():Void;
function teardown(async:Async):Void;
/**
 * This method is executed once after the last test in the current class is finished.
  * If it accepts an argument, it is treated as an asynchronous method.
 */
function teardownClass():Void;
function teardownClass(async:Async):Void;
```
Example:
```haxe
import utest.Assert;
import utest.Async;

class TestCase extends utest.Test {
  var field : String;

 //setup is synchronous
 public function setup() {
    field = "some";
  }

  function testFieldIsSome() {
    Assert.equals("some", field);
  }

  function specField() {
    field.charAt(0) == 's';
    field.length > 3;
  }

  public function teardown(async:Async):Async {
    field = null; // not really needed

    //Adjust timeout. Default is 250ms
    async.setTimeout(1000);
    haxe.Timer.delay(
      function() {
        //resolve asynchronous action
        async.done();
      },
      100
    );
  }
}
```

## Async tests

If a test case accepts an argument, that test case is treated as an asynchronous test.

```haxe
function testSomething(async:utest.Async) {
  //change timeout (default: 250ms)
  async.setTimeout(500);

  // do your async goodness and remember to call `done()` at the end.
  haxe.Timer.delay(function() {
    Assert.isTrue(true); // put a sensible test here
    async.done();
  }, 50);
}
```