### PR TITLE
Add __initializeUtest__ to ITest so it is not removed by full dce

### DIFF
--- a/src/utest/ITest.hx
+++ b/src/utest/ITest.hx
@@ -39,4 +39,10 @@ interface ITest {
 	//  */
 	// function teardownClass():Void;
 	// function teardownClass(async:Async):Void;
+
+	/**
+	 * This method is executed when adding the test case.
+	 * It is automatically generated and should not be overridden.
+	 */
+	@:noCompletion function __initializeUtest__():utest.TestData.InitializeUtest;
 }

--- a/src/utest/Runner.hx
+++ b/src/utest/Runner.hx
@@ -134,7 +134,7 @@ class Runner {
       throw 'Cannot add the same test twice.';
     }
     var fixtures = [];
-    var init:TestData.InitializeUtest = (testCase:Dynamic).__initializeUtest__();
+    var init:TestData.InitializeUtest = testCase.__initializeUtest__();
     for(test in init.tests) {
       if(!isTestFixtureName(test.name, ['test', 'spec'], pattern, globalPattern)) {
         continue;

--- a/src/utest/utils/TestBuilder.hx
+++ b/src/utest/utils/TestBuilder.hx
@@ -49,13 +49,10 @@ class TestBuilder {
 		initExprs.push(macro return init);
 
 		var initialize = (macro class Dummy {
-			@:noCompletion function __initializeUtest__():utest.TestData.InitializeUtest
+			@:noCompletion public function __initializeUtest__():utest.TestData.InitializeUtest
 				$b{initExprs}
 		}).fields[0];
 		if(isOverriding) {
-			if(initialize.access == null) {
-				initialize.access = [];
-			}
 			initialize.access.push(AOverride);
 		}
 


### PR DESCRIPTION
Casting to Dynamic before calling __initializeUtest__ does not work with -dce full.

Not familiar with the code base.  Being a little cautious.  One or all of the test builds should probably be switched to compile with -dce full, but I wasn't sure what you would want.