### PR TITLE
Improve @param formatting

### DIFF
--- a/src/utest/Assert.hx
+++ b/src/utest/Assert.hx
@@ -26,9 +26,9 @@ class Assert {
 
   /**
    * Asserts successfully when the condition is true.
-   * @param cond: The condition to test
-   * @param msg: An optional error message. If not passed a default one will be used
-   * @param pos: Code position where the Assert call has been executed. Don't fill it
+   * @param cond The condition to test
+   * @param msg An optional error message. If not passed a default one will be used
+   * @param pos Code position where the Assert call has been executed. Don't fill it
    * unless you know what you are doing.
    */
   public static function isTrue(cond : Bool, ?msg : String, ?pos : PosInfos) {
@@ -43,9 +43,9 @@ class Assert {
 
   /**
    * Asserts successfully when the condition is false.
-   * @param cond: The condition to test
-   * @param msg: An optional error message. If not passed a default one will be used
-   * @param pos: Code position where the Assert call has been executed. Don't fill it
+   * @param cond The condition to test
+   * @param msg An optional error message. If not passed a default one will be used
+   * @param pos Code position where the Assert call has been executed. Don't fill it
    * unless you know what you are doing.
    */
   public static function isFalse(value : Bool, ?msg : String, ?pos : PosInfos) {
@@ -56,9 +56,9 @@ class Assert {
 
   /**
    * Asserts successfully when the value is null.
-   * @param value: The value to test
-   * @param msg: An optional error message. If not passed a default one will be used
-   * @param pos: Code position where the Assert call has been executed. Don't fill it
+   * @param value The value to test
+   * @param msg An optional error message. If not passed a default one will be used
+   * @param pos Code position where the Assert call has been executed. Don't fill it
    * unless you know what you are doing.
    */
   public static function isNull(value : Dynamic, ?msg : String, ?pos : PosInfos) {
@@ -69,9 +69,9 @@ class Assert {
 
   /**
    * Asserts successfully when the value is not null.
-   * @param value: The value to test
-   * @param msg: An optional error message. If not passed a default one will be used
-   * @param pos: Code position where the Assert call has been executed. Don't fill it
+   * @param value The value to test
+   * @param msg An optional error message. If not passed a default one will be used
+   * @param pos Code position where the Assert call has been executed. Don't fill it
    * unless you know what you are doing.
    */
   public static function notNull(value : Dynamic, ?msg : String, ?pos : PosInfos) {
@@ -82,10 +82,10 @@ class Assert {
 
   /**
    * Asserts successfully when the 'value' parameter is of the of the passed type 'type'.
-   * @param value: The value to test
-   * @param type: The type to test against
-   * @param msg: An optional error message. If not passed a default one will be used
-   * @param pos: Code position where the Assert call has been executed. Don't fill it
+   * @param value The value to test
+   * @param type The type to test against
+   * @param msg An optional error message. If not passed a default one will be used
+   * @param pos Code position where the Assert call has been executed. Don't fill it
    * unless you know what you are doing.
    */
   public static function is(value : Dynamic, type : Dynamic, ?msg : String , ?pos : PosInfos) {
@@ -98,10 +98,10 @@ class Assert {
    * ```haxe
    * Assert.notEquals(10, age);
    * ```
-   * @param expected: The expected value to check against
-   * @param value: The value to test
-   * @param msg: An optional error message. If not passed a default one will be used
-   * @param pos: Code position where the Assert call has been executed. Don't fill it
+   * @param expected The expected value to check against
+   * @param value The value to test
+   * @param msg An optional error message. If not passed a default one will be used
+   * @param pos Code position where the Assert call has been executed. Don't fill it
    * unless you know what you are doing.
    */
   public static function notEquals(expected : Dynamic, value : Dynamic, ?msg : String , ?pos : PosInfos) {
@@ -114,10 +114,10 @@ class Assert {
    * ```haxe
    * Assert.equals(10, age);
    * ```
-   * @param expected: The expected value to check against
-   * @param value: The value to test
-   * @param msg: An optional error message. If not passed a default one will be used
-   * @param pos: Code position where the Assert call has been executed. Don't fill it
+   * @param expected The expected value to check against
+   * @param value The value to test
+   * @param msg An optional error message. If not passed a default one will be used
+   * @param pos Code position where the Assert call has been executed. Don't fill it
    * unless you know what you are doing.
    */
   public static function equals(expected : Dynamic, value : Dynamic, ?msg : String , ?pos : PosInfos) {
@@ -130,10 +130,10 @@ class Assert {
    * ```haxe
    * Assert.match(~/x/i, "haXe");
    * ```
-   * @param pattern: The pattern to match against
-   * @param value: The value to test
-   * @param msg: An optional error message. If not passed a default one will be used
-   * @param pos: Code position where the Assert call has been executed. Don't fill it
+   * @param pattern The pattern to match against
+   * @param value The value to test
+   * @param msg An optional error message. If not passed a default one will be used
+   * @param pos Code position where the Assert call has been executed. Don't fill it
    * unless you know what you are doing.
    */
   public static function match(pattern : EReg, value : Dynamic, ?msg : String , ?pos : PosInfos) {
@@ -146,11 +146,11 @@ class Assert {
    * ```haxe
    * Assert.floatEquals(Math.PI, value);
    * ```
-   * @param expected: The expected value to check against
-   * @param value: The value to test
-   * @param approx: The approximation tollerance. Default is 1e-5
-   * @param msg: An optional error message. If not passed a default one will be used
-   * @param pos: Code position where the Assert call has been executed. Don't fill it
+   * @param expected The expected value to check against
+   * @param value The value to test
+   * @param approx The approximation tollerance. Default is 1e-5
+   * @param msg An optional error message. If not passed a default one will be used
+   * @param pos Code position where the Assert call has been executed. Don't fill it
    * unless you know what you are doing.
    * @todo test the approximation argument
    */
@@ -505,13 +505,13 @@ class Assert {
    * ```haxe
    * Assert.same({ name : "utest"}, ob);
    * ```
-   * @param expected: The expected value to check against
-   * @param value: The value to test
-   * @param recursive: States whether or not the test will apply also to sub-objects.
+   * @param expected The expected value to check against
+   * @param value The value to test
+   * @param recursive States whether or not the test will apply also to sub-objects.
    * Defaults to true
-   * @param msg: An optional error message. If not passed a default one will be used
-   * @param approx: The approximation tollerance. Default is 1e-5
-   * @param pos: Code position where the Assert call has been executed. Don't fill it
+   * @param msg An optional error message. If not passed a default one will be used
+   * @param approx The approximation tollerance. Default is 1e-5
+   * @param pos Code position where the Assert call has been executed. Don't fill it
    * unless you know what you are doing.
    */
   public static function same(expected : Dynamic, value : Dynamic, ?recursive : Bool, ?msg : String, ?approx : Float,  ?pos : PosInfos) {
@@ -532,13 +532,13 @@ class Assert {
    * ```haxe
    * Assert.raises(function() { throw "Error!"; }, String);
    * ```
-   * @param method: A method that generates the exception.
-   * @param type: The type of the expected error. Defaults to Dynamic (catch all).
-   * @param msgNotThrown: An optional error message used when the function fails to raise the expected
+   * @param method A method that generates the exception.
+   * @param type The type of the expected error. Defaults to Dynamic (catch all).
+   * @param msgNotThrown An optional error message used when the function fails to raise the expected
    *      exception. If not passed a default one will be used
-   * @param msgWrongType: An optional error message used when the function raises the exception but it is
+   * @param msgWrongType An optional error message used when the function raises the exception but it is
    *      of a different type than the one expected. If not passed a default one will be used
-   * @param pos: Code position where the Assert call has been executed. Don't fill it
+   * @param pos Code position where the Assert call has been executed. Don't fill it
    * unless you know what you are doing.
    */
   public static function raises(method:Void -> Void, ?type:Class<Dynamic>, ?msgNotThrown : String , ?msgWrongType : String, ?pos : PosInfos) {
@@ -561,10 +561,10 @@ class Assert {
 
   /**
    * Checks that the test value matches at least one of the possibilities.
-   * @param possibility: An array of possible matches
-   * @param value: The value to test
-   * @param msg: An optional error message. If not passed a default one will be used
-   * @param pos: Code position where the Assert call has been executed. Don't fill it
+   * @param possibility An array of possible matches
+   * @param value The value to test
+   * @param msg An optional error message. If not passed a default one will be used
+   * @param pos Code position where the Assert call has been executed. Don't fill it
    * unless you know what you are doing.
    */
   public static function allows<T>(possibilities : Array<T>, value : T, ?msg : String , ?pos : PosInfos) {
@@ -577,10 +577,10 @@ class Assert {
 
   /**
    * Checks that the test array contains the match parameter.
-   * @param match: The element that must be included in the tested array
-   * @param values: The values to test
-   * @param msg: An optional error message. If not passed a default one will be used
-   * @param pos: Code position where the Assert call has been executed. Don't fill it
+   * @param match The element that must be included in the tested array
+   * @param values The values to test
+   * @param msg An optional error message. If not passed a default one will be used
+   * @param pos Code position where the Assert call has been executed. Don't fill it
    * unless you know what you are doing.
    */
   public static function contains<T>(match : T, values : Array<T>, ?msg : String , ?pos : PosInfos) {
@@ -593,10 +593,10 @@ class Assert {
 
   /**
    * Checks that the test array does not contain the match parameter.
-   * @param match: The element that must NOT be included in the tested array
-   * @param values: The values to test
-   * @param msg: An optional error message. If not passed a default one will be used
-   * @param pos: Code position where the Assert call has been executed. Don't fill it
+   * @param match The element that must NOT be included in the tested array
+   * @param values The values to test
+   * @param msg An optional error message. If not passed a default one will be used
+   * @param pos Code position where the Assert call has been executed. Don't fill it
    * unless you know what you are doing.
    */
   public static function notContains<T>(match : T, values : Array<T>, ?msg : String , ?pos : PosInfos) {
@@ -609,10 +609,10 @@ class Assert {
 
   /**
    * Checks that the expected values is contained in value.
-   * @param match: the string value that must be contained in value
-   * @param value: the value to test
-   * @param msg: An optional error message. If not passed a default one will be used
-   * @param pos: Code position where the Assert call has been executed.
+   * @param match the string value that must be contained in value
+   * @param value the value to test
+   * @param msg An optional error message. If not passed a default one will be used
+   * @param pos Code position where the Assert call has been executed.
    */
   public static function stringContains(match : String, value : String, ?msg : String , ?pos : PosInfos) {
     if (value != null && value.indexOf(match) >= 0) {
@@ -625,10 +625,10 @@ class Assert {
   /**
    * Checks that the test string contains all the values in `sequence` in the order
    * they are defined.
-   * @param sequence: the values to match in the string
-   * @param value: the value to test
-   * @param msg: An optional error message. If not passed a default one is be used
-   * @param pos: Code position where the Assert call has been executed.
+   * @param sequence the values to match in the string
+   * @param value the value to test
+   * @param msg An optional error message. If not passed a default one is be used
+   * @param pos Code position where the Assert call has been executed.
    */
   public static function stringSequence(sequence : Array<String>, value : String, ?msg : String , ?pos : PosInfos) {
     if (null == value)
@@ -664,8 +664,8 @@ class Assert {
 
   /**
    * Adds a successful assertion for cases where there are no values to assert.
-   * @param msg: An optional success message. If not passed a default one will be used
-   * @param pos: Code position where the Assert call has been executed. Don't fill it
+   * @param msg An optional success message. If not passed a default one will be used
+   * @param pos Code position where the Assert call has been executed. Don't fill it
    * unless you know what you are doing.
    */
   public static function pass(msg = "pass expected", ?pos : PosInfos) {
@@ -674,8 +674,8 @@ class Assert {
 
   /**
    * Forces a failure.
-   * @param msg: An optional error message. If not passed a default one will be used
-   * @param pos: Code position where the Assert call has been executed. Don't fill it
+   * @param msg An optional error message. If not passed a default one will be used
+   * @param pos Code position where the Assert call has been executed. Don't fill it
    * unless you know what you are doing.
    */
   public static function fail(msg = "failure expected", ?pos : PosInfos) {
@@ -684,8 +684,8 @@ class Assert {
 
   /**
    * Creates a warning message.
-   * @param msg: A mandatory message that justifies the warning.
-   * @param pos: Code position where the Assert call has been executed. Don't fill it
+   * @param msg A mandatory message that justifies the warning.
+   * @param pos Code position where the Assert call has been executed. Don't fill it
    * unless you know what you are doing.
    */
   public static function warn(msg) {
@@ -701,8 +701,8 @@ class Assert {
    *   haxe.Timer.delay(async, 50);
    * }
    * ```
-   * @param f: A function that contains other Assert tests
-   * @param timeout: Optional timeout value in milliseconds.
+   * @param f A function that contains other Assert tests
+   * @param timeout Optional timeout value in milliseconds.
    */
   public static dynamic function createAsync(?f : Void -> Void, ?timeout : Int) {
     return function(){};
@@ -713,8 +713,8 @@ class Assert {
    * Assertions should be included in the passed function.
    * It works the same way as Assert.createAsync() but accepts a function with one
    * argument (usually some event data) instead of a function with no arguments
-   * @param f: A function that contains other Assert tests
-   * @param timeout: Optional timeout value in milliseconds.
+   * @param f A function that contains other Assert tests
+   * @param timeout Optional timeout value in milliseconds.
    */
   public static dynamic function createEvent<EventArg>(f : EventArg -> Void, ?timeout : Int) {
     return function(e){};

--- a/src/utest/Assertation.hx
+++ b/src/utest/Assertation.hx
@@ -10,7 +10,7 @@ import haxe.PosInfos;
 enum Assertation {
   /**
    * Assertion is succesful
-   * @param pos: Code position where the Assert call has been executed
+   * @param pos Code position where the Assert call has been executed
    */
   Success(pos:PosInfos);
 
@@ -18,54 +18,54 @@ enum Assertation {
    * Assertion is a falure. This does not denote an error in the assertion
    * code but that the testing condition has failed for some reason.
    * Ei.: Assert.isTrue(1 == 0);
-   * @param msg: An error message containing the reasons for the failure.
-   * @param pos: Code position where the Assert call has been executed
+   * @param msg An error message containing the reasons for the failure.
+   * @param pos Code position where the Assert call has been executed
    */
   Failure(msg:String, pos:PosInfos);
 
   /**
    * An error has occurred during the execution of the test that prevents
    * futher assertion to be tested.
-   * @param e: The captured error/exception
+   * @param e The captured error/exception
    */
   Error(e:Dynamic, stack:Array<StackItem>);
 
   /**
    * An error has occurred during the Setup phase of the test. It prevents
    * the test to be run.
-   * @param e: The captured error/exception
+   * @param e The captured error/exception
    */
   SetupError(e:Dynamic, stack:Array<StackItem>);
 
   /**
    * An error has occurred during the Teardown phase of the test.
-   * @param e: The captured error/exception
+   * @param e The captured error/exception
    */
   TeardownError(e:Dynamic, stack:Array<StackItem>);
 
   /**
    * The asynchronous phase of a test has gone into timeout.
-   * @param missedAsyncs: The number of asynchronous calls that was expected
+   * @param missedAsyncs The number of asynchronous calls that was expected
    * to be performed before the timeout.
    */
   TimeoutError(missedAsyncs:Int, stack:Array<StackItem>);
 
   /**
    * An error has occurred during an asynchronous test.
-   * @param e: The captured error/exception
+   * @param e The captured error/exception
    */
   AsyncError(e:Dynamic, stack:Array<StackItem>);
 
   /**
    * A warning state. This can be declared explicitely by an Assert call
    * or can denote a test method that contains no assertions at all.
-   * @param msg: The reason behind the warning
+   * @param msg The reason behind the warning
    */
   Warning(msg:String);
 
   /**
    * Test is ignored.
-   * @param reason: Reason of test ignoring.
+   * @param reason Reason of test ignoring.
    */
   Ignore(reason:String);
 }

--- a/src/utest/MacroRunner.hx
+++ b/src/utest/MacroRunner.hx
@@ -32,7 +32,7 @@ Run the unit tests from a macro, displaying errors and a summary in the macro Co
 
 /**
 Displays stub code for using MacroRunner.
-@param n: String of test class to use, "package.ClassName" for example.
+@param n String of test class to use, "package.ClassName" for example.
 @todo Parse real package/class references instead of just a string.
 */
   macro public static function generateMainCode(n : Expr) {

--- a/src/utest/Runner.hx
+++ b/src/utest/Runner.hx
@@ -95,7 +95,7 @@ class Runner {
   /**
    * Get the value for a setting provided by haxe define flag (-D name=value) or by an environment variable at compile time.
    * If both -D and env var are provided, then the value provided by -D is used.
-   * @param name - the name of a defined value or of an environment variable.
+   * @param name the name of a defined value or of an environment variable.
    */
   macro static function getEnvSetting(name:String):ExprOf<Null<String>> {
     var value = Context.definedValue(name);
@@ -107,14 +107,14 @@ class Runner {
 
   /**
    * Adds a new test case.
-   * @param  test: must be a not null object
-   * @param  setup: string name of the setup function (defaults to "setup")
-   * @param  teardown: string name of the teardown function (defaults to "teardown")
-   * @param  prefix: prefix for methods that are tests (defaults to "test")
-   * @param  pattern: a regular expression that discriminates the names of test
+   * @param test must be a not null object
+   * @param setup string name of the setup function (defaults to "setup")
+   * @param teardown string name of the teardown function (defaults to "teardown")
+   * @param prefix prefix for methods that are tests (defaults to "test")
+   * @param pattern a regular expression that discriminates the names of test
    *       functions; when set,  the prefix parameter is meaningless
-   * @param  setupAsync: string name of the asynchronous setup function (defaults to "setupAsync")
-   * @param  teardownAsync: string name of the asynchronous teardown function (defaults to "teardownAsync")
+   * @param setupAsync string name of the asynchronous setup function (defaults to "setupAsync")
+   * @param teardownAsync string name of the asynchronous teardown function (defaults to "teardownAsync")
    */
   public function addCase(test : Dynamic, setup = "setup", teardown = "teardown", prefix = "test", ?pattern : EReg, setupAsync = "setupAsync", teardownAsync = "teardownAsync") {
     #if (haxe_ver >= "3.4.0")
@@ -170,11 +170,11 @@ class Runner {
   }
 
   /**
-   *  Add all test cases located in specified package `path`.
-   *  Any module found in `path` is treated as a test case.
-   *  That means each module should contain a class with a constructor and with the same name as a module name.
-   *  @param path - dot-separated path as a string or as an identifier/field expression. E.g. `"my.pack"` or `my.pack`
-   *  @param recursive - recursively look for test cases in sub packages.
+   * Add all test cases located in specified package `path`.
+   * Any module found in `path` is treated as a test case.
+   * That means each module should contain a class with a constructor and with the same name as a module name.
+   * @param path dot-separated path as a string or as an identifier/field expression. E.g. `"my.pack"` or `my.pack`
+   * @param recursive recursively look for test cases in sub packages.
    */
   macro public function addCases(eThis:Expr, path:Expr, recursive:Bool = true):Expr {
     if(Context.defined('display')) {


### PR DESCRIPTION
I think the `:` after the parameter names was an old FD bug or something? Either way, it doesn't belong there and breaks JavaDoc highlighting with haxe-tmLanguage, as can be seen in the diff here or in VSCode.