### PR TITLE
@:keep __initializeUtest__()

### DIFF
--- a/src/utest/utils/TestBuilder.hx
+++ b/src/utest/utils/TestBuilder.hx
@@ -49,7 +49,7 @@ class TestBuilder {
 		initExprs.push(macro return init);
 
 		var initialize = (macro class Dummy {
-			@:noCompletion function __initializeUtest__():utest.TestData.InitializeUtest
+			@:noCompletion @:keep function __initializeUtest__():utest.TestData.InitializeUtest
 				$b{initExprs}
 		}).fields[0];
 		if(isOverriding) {


### PR DESCRIPTION
Without this, I got "testCase.__initializeUtest__ is not a function" (with DCE enabled).