### PR TITLE
Update URL in haxelib.json

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -1,6 +1,6 @@
 {
   "name": "utest",
-  "url": "https://github.com/fponticelli/utest",
+  "url": "https://github.com/haxe-utest/utest",
   "license": "MIT",
   "tags": ["cross","unittesting"],
   "description": "Unit Testing for Haxe",


### PR DESCRIPTION
The old URL now points to a fork: https://github.com/fponticelli/utest