### PR TITLE
Make UTest final

### DIFF
--- a/src/utest/UTest.hx
+++ b/src/utest/UTest.hx
@@ -3,7 +3,7 @@ package utest;
 /**
  * Helper class to quickly generate test cases.
  */
-class UTest {
+@:final class UTest {
   public static function run(cases : Array<{}>, ?callback : Void->Void) {
     var runner = new Runner();
     for(eachCase in cases)


### PR DESCRIPTION
(to avoid accidentally extending from `UTest` instead of `utest.Test`)