### PR TITLE
fix bad signature in UTest.run

### DIFF
--- a/src/utest/UTest.hx
+++ b/src/utest/UTest.hx
@@ -4,7 +4,7 @@ package utest;
  * Helper class to quickly generate test cases.
  */
 @:final class UTest {
-  public static function run(cases : Array<{}>, ?callback : Void->Void) {
+  public static function run<T:{}>(cases : Array<T>, ?callback : Void->Void) {
     var runner = new Runner();
     for(eachCase in cases)
       runner.addCase(eachCase);


### PR DESCRIPTION
This leads to variance problems when the array isn't declared directly against the call argument.