### PR TITLE
Support PosInfos as test parameter

### DIFF
--- a/src/utest/utils/TestBuilder.hx
+++ b/src/utest/utils/TestBuilder.hx
@@ -77,7 +77,20 @@ class TestBuilder {
 
 	static function processTest(cls:ClassType, field:Field, fn:Function, initExprs:Array<Expr>) {
 		var test = field.name;
-		switch(fn.args.length) {
+		var posInfos = 0;
+
+		if (fn.args.length >= 1) {
+			switch (fn.args[fn.args.length - 1].type) {
+				case TPath(p):
+					if (p.pack.length == 0 && p.name == "PosInfos") {
+						posInfos = 1;
+					}
+
+				default:
+			}
+		}
+
+		switch(fn.args.length - posInfos) {
 			//synchronous test
 			case 0:
 				initExprs.push(macro @:pos(field.pos) init.tests.push({


### PR DESCRIPTION
If you a test like this:
```haxe
public function testSomething(?pos:PosInfos):Void
```
you'll get the error `utest.Async should be Null<haxe.PosInfos>`.

And if you do:
```haxe
public function testSomething(_, ?pos:PosInfos):Void
```
then `Wrong arguments count. The only supported argument is utest.Async for asynchronous tests.`.

I need this because most of my tests are like this:
```haxe
public function testSomething():Void {
    compare("samples/Something.hx");
}
```
where the compare function has the asserts, and so the line number are for the wrong file.

I'm not 100% sure this is reliable though, somehow the pack is empty? Maybe because I imported it.
But in that case I don't know how to check if it's not another class with the same name.