### PR TITLE
avoid "async" Python keyword

### DIFF
--- a/src/utest/utils/AsyncUtils.hx
+++ b/src/utest/utils/AsyncUtils.hx
@@ -1,7 +1,7 @@
 package utest.utils;
 
 class AsyncUtils {
-	static public inline function orResolved(async:Null<Async>):Async {
-		return async == null ? Async.getResolved() : async;
+	static public inline function orResolved(_async:Null<Async>):Async {
+		return _async == null ? Async.getResolved() : _async;
 	}
 }


### PR DESCRIPTION
Haxe 3.4.7 doesn't rename the argument.

And it was not caught by the tests since this AsyncUtils class was removed by dce...