### PR TITLE
Remove xmldoc defines

### DIFF
--- a/doc/build_doc.hxml
+++ b/doc/build_doc.hxml
@@ -27,22 +27,18 @@ ImportUTest
 --next
 -xml xml/cpp.xml
 -cpp _
--D xmldoc
 
 --next
 -xml xml/java.xml
 -java _
--D xmldoc
 
 --next
 -xml xml/cs.xml
 -cs _
--D xmldoc
 
 #--next
 #-xml xml/python.xml
 #-python _
-#-D xmldoc
 
 #--next
 #-xml xml/cross.xml


### PR DESCRIPTION
That define is no longer checked anywhere, `doc_gen` is used instead.