### PR TITLE
Convert failures to unhandled exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,16 @@ function testSomething(async:utest.Async) {
 }
 ```
 
+## Convert failures into exceptions
+
+It is possible to make UTest throw an unhandled exception instead of adding a failure to the report.
+
+Enable this behavior with `-D UTEST_FAILURE_THROW`.
+
+In this case any exception or failure in test or setup methods will lead to a crash.
+Instead of a test report you will see an unhandled exception message with the exception
+stack trace (depending on a target platform).
+
 ## Assert
 
 [Assert](src/utest/Assert.hx) contains a plethora of methods to perform your tests:

--- a/compat/unit/Test.hx
+++ b/compat/unit/Test.hx
@@ -24,10 +24,11 @@ class Test {
   function exc(f : Void -> Void, ?pos) {
     try {
       f();
-      Assert.fail("No exception occured",pos);
     } catch(e : Dynamic) {
       Assert.isTrue(true, pos);
+      return;
     }
+    Assert.fail("No exception occured",pos);
   }
 
   function unspec(f : Void -> Void, ?pos) {

--- a/src/utest/Assert.hx
+++ b/src/utest/Assert.hx
@@ -30,8 +30,13 @@ class Assert {
     }
     if(cond)
       results.add(Success(pos));
-    else
+    else {
+      #if UTEST_FAILURE_THROW
+      throw '${pos.fileName}:${pos.lineNumber}: ${getMessage()}';
+      #else
       results.add(Failure(getMessage(), pos));
+      #end
+    }
   }
 
   /**
@@ -546,9 +551,6 @@ class Assert {
     var name = type != null ? Type.getClassName(type) : "Dynamic";
     try {
       method();
-      if (null == msgNotThrown)
-        msgNotThrown = "exception of type " + name + " not raised";
-      fail(msgNotThrown, pos);
     } catch (ex : Dynamic) {
       if(null == type) {
         pass(pos);
@@ -557,7 +559,11 @@ class Assert {
           msgWrongType = "expected throw of type " + name + " but it is "  + ex;
         isTrue(Std.is(ex, type), msgWrongType, pos);
       }
+      return;
     }
+    if (null == msgNotThrown)
+      msgNotThrown = "exception of type " + name + " not raised";
+    fail(msgNotThrown, pos);
   }
 
   /**

--- a/src/utest/ITestHandler.hx
+++ b/src/utest/ITestHandler.hx
@@ -35,11 +35,14 @@ class ITestHandler<T> extends TestHandler<T> {
 	function runSetup() {
 		try {
 			setupAsync = fixture.setupMethod();
-		} catch(e:Dynamic) {
+		}
+		#if !UTEST_FAILURE_THROW
+		catch(e:Dynamic) {
 			results.add(SetupError(e, CallStack.exceptionStack()));
 			completedFinally();
 			return;
 		}
+		#end
 
 		setupAsync.then(checkSetup);
 	}
@@ -56,11 +59,14 @@ class ITestHandler<T> extends TestHandler<T> {
 	function runTest() {
 		try {
 			testAsync = test.execute();
-		} catch(e:Dynamic) {
+		}
+		#if !UTEST_FAILURE_THROW
+		catch(e:Dynamic) {
 			results.add(Error(e, CallStack.exceptionStack()));
 			runTeardown();
 			return;
 		}
+		#end
 
 		testAsync.then(checkTest);
 	}
@@ -88,11 +94,14 @@ class ITestHandler<T> extends TestHandler<T> {
 	function runTeardown() {
 		try {
 			teardownAsync = fixture.teardownMethod();
-		} catch(e:Dynamic) {
+		}
+		#if !UTEST_FAILURE_THROW
+		catch(e:Dynamic) {
 			results.add(TeardownError(e, CallStack.exceptionStack()));
 			completedFinally();
 			return;
 		}
+		#end
 
 		teardownAsync.then(checkTeardown);
 	}

--- a/src/utest/Runner.hx
+++ b/src/utest/Runner.hx
@@ -139,13 +139,13 @@ class Runner {
       throw 'Cannot add the same test twice.';
     }
     var fixtures = [];
-	#if as3
-	// AS3 can't handle the ECheckType cast. Let's dodge the issue.
-	var tmp:TestData.Initializer = cast testCase;
-	var init:TestData.InitializeUtest = tmp.__initializeUtest__();
-	#else
+  #if as3
+  // AS3 can't handle the ECheckType cast. Let's dodge the issue.
+  var tmp:TestData.Initializer = cast testCase;
+  var init:TestData.InitializeUtest = tmp.__initializeUtest__();
+  #else
     var init:TestData.InitializeUtest = (cast testCase:TestData.Initializer).__initializeUtest__();
-	#end
+  #end
     for(test in init.tests) {
       if(!isTestFixtureName(test.name, ['test', 'spec'], pattern, globalPattern)) {
         continue;
@@ -350,10 +350,13 @@ private class ITestRunner {
       teardownClass = data.teardownClass;
       try {
         setupAsync = data.setupClass();
-      } catch(e:Dynamic) {
+      }
+      #if !UTEST_FAILURE_THROW
+      catch(e:Dynamic) {
         setupFailed(SetupError('setupClass failed: $e', CallStack.exceptionStack()));
         return;
       }
+      #end
       if(setupAsync.resolved) {
         if(!runFixtures()) return;
       } else {
@@ -397,10 +400,13 @@ private class ITestRunner {
     //no fixtures left in the current case
     try {
       teardownAsync = teardownClass();
-    } catch(e:Dynamic) {
+    }
+    #if !UTEST_FAILURE_THROW
+    catch(e:Dynamic) {
       teardownFailed(TeardownError('teardownClass failed: $e', CallStack.exceptionStack()));
       return true;
     }
+    #end
     //case was executed synchronously from `runCases()`
     if(teardownAsync.resolved && finishedHandler == null) {
       return true;

--- a/src/utest/TestHandler.hx
+++ b/src/utest/TestHandler.hx
@@ -58,9 +58,12 @@ class TestHandler<T> {
       if(!expectingAsync) {
         executeFixtureMethod();
       }
-    } catch(e : Dynamic) {
+    }
+    #if !UTEST_FAILURE_THROW
+    catch(e : Dynamic) {
       results.add(SetupError(e, exceptionStack()));
     }
+    #end
     isSync = false;
     if(!expectingAsync) {
       executeFinally();
@@ -70,9 +73,12 @@ class TestHandler<T> {
   function executeFixtureMethod() {
     try {
       executeMethod(fixture.method);
-    } catch (e : Dynamic) {
+    }
+    #if !UTEST_FAILURE_THROW
+    catch (e : Dynamic) {
       results.add(Error(e, exceptionStack()));
     }
+    #end
   }
 
   function executeFinally() {
@@ -166,9 +172,12 @@ class TestHandler<T> {
       try {
         handler.bindHandler();
         f();
-      } catch(e : Dynamic) {
+      }
+      #if !UTEST_FAILURE_THROW
+      catch(e : Dynamic) {
         handler.results.add(AsyncError(e, exceptionStack(0))); // TODO check the correct number of functions is popped from the stack
       }
+      #end
     };
   }
 
@@ -184,9 +193,12 @@ class TestHandler<T> {
       try {
         handler.bindHandler();
         f(e);
-      } catch(e : Dynamic) {
+      }
+      #if !UTEST_FAILURE_THROW
+      catch(e : Dynamic) {
         handler.results.add(AsyncError(e, exceptionStack(0))); // TODO check the correct number of functions is popped from the stack
       }
+      #end
     };
   }
 
@@ -238,9 +250,12 @@ class TestHandler<T> {
     try {
       executeMethod(fixture.teardown);
       executeAsyncMethod(fixture.teardownAsync, complete);
-    } catch(e : Dynamic) {
+    }
+    #if !UTEST_FAILURE_THROW
+    catch(e : Dynamic) {
       results.add(TeardownError(e, exceptionStack(2))); // TODO check the correct number of functions is popped from the stack
     }
+    #end
     isSync = false;
     if(!expectingAsync) {
       completedFinally();


### PR DESCRIPTION
Closes #84 

Enable this behavior with `-D UTEST_FAILURE_THROW`.

In this case any exception or failure in test or setup methods will lead to a crash.
Instead of a test report you will see an unhandled exception message with the exception
stack trace (depending on a target platform).