### PR TITLE
Accept UTEST_PRINT_TESTS and UTEST_FAILURE_THROW via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ class TestCase extends utest.Test {
 
 Adding `-D UTEST_PATTERN=pattern` to the compilation flags makes UTest to run only tests which have names matching the `pattern`. The pattern could be a plain string or a regular expression without delimiters.
 
-Another option is to add `UTEST_PATTERN` to the environment variables at compile time.
+Another option is to pass a `UTEST_PATTERN` environment variable at compile time.
 
 ## Async tests
 
@@ -170,11 +170,13 @@ Running my.tests.TestAnother...
 ```
 And after finishing all the tests UTest will print usual report.
 
+Another option is to pass a non-empty `UTEST_PRINT_TESTS` environment variable at compile time.
+
 ## Convert failures into exceptions
 
 It is possible to make UTest throw an unhandled exception instead of adding a failure to the report.
 
-Enable this behavior with `-D UTEST_FAILURE_THROW`.
+Enable this behavior with `-D UTEST_FAILURE_THROW`, or by passing a non-empty `UTEST_FAILURE_THROW` environment variable at compile time.
 
 In this case any exception or failure in test or setup methods will lead to a crash.
 Instead of a test report you will see an unhandled exception message with the exception

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ class TestCase extends utest.Test {
 
 Adding `-D UTEST_PATTERN=pattern` to the compilation flags makes UTest to run only tests which have names matching the `pattern`. The pattern could be a plain string or a regular expression without delimiters.
 
-Another option is to pass a `UTEST_PATTERN` environment variable at compile time.
+Another option is to add `UTEST_PATTERN` to the environment variables at compile time.
 
 ## Async tests
 
@@ -170,13 +170,13 @@ Running my.tests.TestAnother...
 ```
 And after finishing all the tests UTest will print usual report.
 
-Another option is to pass a non-empty `UTEST_PRINT_TESTS` environment variable at compile time.
+Another option is to add `UTEST_PRINT_TESTS` to the environment variables at compile time.
 
 ## Convert failures into exceptions
 
 It is possible to make UTest throw an unhandled exception instead of adding a failure to the report.
 
-Enable this behavior with `-D UTEST_FAILURE_THROW`, or by passing a non-empty `UTEST_FAILURE_THROW` environment variable at compile time.
+Enable this behavior with `-D UTEST_FAILURE_THROW`, or by adding `UTEST_FAILURE_THROW` to the environment variables at compile time.
 
 In this case any exception or failure in test or setup methods will lead to a crash.
 Instead of a test report you will see an unhandled exception message with the exception

--- a/extraParams.hxml
+++ b/extraParams.hxml
@@ -1,1 +1,2 @@
 --macro utest.utils.Macro.checkHaxe()
+--macro utest.utils.Macro.importEnvSettings()

--- a/src/utest/Runner.hx
+++ b/src/utest/Runner.hx
@@ -2,6 +2,7 @@ package utest;
 
 import utest.utils.Print;
 import haxe.CallStack;
+import haxe.macro.Compiler;
 import utest.Dispatcher;
 #if macro
 import haxe.macro.Context;
@@ -92,23 +93,10 @@ class Runner {
     onTestComplete = new Dispatcher();
     length = 0;
 
-    var envPattern = getEnvSetting('UTEST_PATTERN');
+    var envPattern = Compiler.getDefine('UTEST_PATTERN');
     if(envPattern != null) {
       globalPattern = new EReg(envPattern, '');
     }
-  }
-
-  /**
-   * Get the value for a setting provided by haxe define flag (-D name=value) or by an environment variable at compile time.
-   * If both -D and env var are provided, then the value provided by -D is used.
-   * @param name the name of a defined value or of an environment variable.
-   */
-  macro static function getEnvSetting(name:String):ExprOf<Null<String>> {
-    var value = Context.definedValue(name);
-    if(value == null) {
-      value = Sys.getEnv(name);
-  }
-    return macro $v{value};
   }
 
   /**

--- a/src/utest/utils/Macro.hx
+++ b/src/utest/utils/Macro.hx
@@ -1,5 +1,6 @@
 package utest.utils;
 
+import haxe.macro.Compiler;
 import haxe.macro.Context;
 
 class Macro {
@@ -7,6 +8,15 @@ class Macro {
 		#if (haxe_ver < '3.4.0')
 		Context.warning('UTest will stop supporting Haxe 3.3 and older in UTest 2.0.0', Context.currentPos());
 		#end
-		return macro {}
+		return macro {};
+	}
+
+	macro static public function importEnvSettings() {
+		var env = Sys.environment();
+		for (name in env.keys()) {
+			if (name.indexOf('UTEST_') == 0 && !Context.defined(name))
+				Compiler.define(name, env[name]);
+		}
+		return macro {};
 	}
 }


### PR DESCRIPTION
Import UTEST_PRINT_TESTS and UTEST_FAILURE_THROW from the compiler environment, in addition to UTEST_PATTERN.

This is implemented with a generic initialization macro, and will support any UTEST_* flag.
