### PR TITLE
UTest.run(): adds the `onComplete` callback before instantiating the report.

### DIFF
--- a/src/utest/UTest.hx
+++ b/src/utest/UTest.hx
@@ -8,9 +8,9 @@ package utest;
     var runner = new Runner();
     for(eachCase in cases)
       runner.addCase(eachCase);
-    utest.ui.Report.create(runner);
     if(null != callback)
-    runner.onComplete.add(function(_) callback());
+      runner.onComplete.add(function(_) callback());
+    utest.ui.Report.create(runner);
     runner.run();
   }
 }


### PR DESCRIPTION
Fixes #100.