### PR TITLE
Use `enum abstract` where available.

### DIFF
--- a/src/utest/utils/TestBuilder.hx
+++ b/src/utest/utils/TestBuilder.hx
@@ -9,8 +9,8 @@ import haxe.macro.ExprTools;
 
 using Lambda;
 
-#if !haxe4 @:enum #end
-private #if haxe4 enum #end abstract IsAsync(Int) {
+#if haxe4 private enum #else @:enum private #end
+abstract IsAsync(Int) {
 	var Yes = 1;
 	var No = 0;
 	var Unknown = -1;

--- a/src/utest/utils/TestBuilder.hx
+++ b/src/utest/utils/TestBuilder.hx
@@ -9,8 +9,8 @@ import haxe.macro.ExprTools;
 
 using Lambda;
 
-@:enum
-private abstract IsAsync(Int) {
+#if !haxe4 @:enum #end
+private #if haxe4 enum #end abstract IsAsync(Int) {
 	var Yes = 1;
 	var No = 0;
 	var Unknown = -1;


### PR DESCRIPTION
The old syntax is deprecated as of Haxe 4.3.