### PR TITLE
Merge `raisesCondition()` into `raises()` using `EitherType`.

### DIFF
--- a/src/utest/Assert.hx
+++ b/src/utest/Assert.hx
@@ -682,6 +682,7 @@ class Assert {
     // } catch(ex:ValueException) {
     //   return handleCatch(ex.value);
     } catch (ex) {
+      var ex = Std.isOfType(ex, ValueException) ? (cast ex:ValueException).value : ex;
       inline function checkCondition():Bool {
         return if(null == condition) {
           pass(pos);
@@ -691,9 +692,6 @@ class Assert {
           isTrue(condition(cast ex), msgWrongCondition, pos);
         }
       }
-      
-      if(Std.isOfType(ex, ValueException))
-        ex = (cast ex:ValueException).value;
       return if(null == type) {
         checkCondition();
       } else {

--- a/src/utest/Assert.hx
+++ b/src/utest/Assert.hx
@@ -685,7 +685,7 @@ class Assert {
     // } catch(ex:ValueException) {
     //   return handleCatch(ex.value);
     } catch (ex) {
-      var ex = Std.isOfType(ex, ValueException) ? (cast ex:ValueException).value : ex;
+      var ex = Std.isOfType(ex, ValueException) ? (cast ex:ValueException).value : (ex:Any);
       inline function checkCondition():Bool {
         return if(null == condition) {
           pass(pos);

--- a/src/utest/Assert.hx
+++ b/src/utest/Assert.hx
@@ -661,7 +661,8 @@ class Assert {
    * @param type The type of the expected error. Defaults to any type (catch all).
    * @param condition The callback which is called upon an exception. The assertion passes
    *      if this callback returns `true`. Otherwise assertion fails. If `type` is specified, that
-   *      will have already been checked before the function is called.
+   *      will have already been checked before the function is called. In JavaScript, you must
+   *      specify `type`.
    * @param msgNotThrown An optional error message used when the function fails to raise the expected
    *      exception. If not passed a default one will be used
    * @param msgWrongType An optional error message used when the function raises the exception but it is
@@ -671,10 +672,12 @@ class Assert {
    * unless you know what you are doing.
    */
   public static function raises<T>(method:() -> Void, ?type:EitherType<Class<T>, Any>, ?condition:(e:T)->Bool, ?msgNotThrown : String , ?msgWrongType : String, ?msgWrongCondition : String, ?pos : PosInfos) : Bool {
+    #if !js
     if(Reflect.isFunction(type)) {
       condition = (type:Any);
       type = null;
     }
+    #end
     var typeDescr = type != null ? "exception of type " + Type.getClassName(type) : "exception";
     try {
       method();

--- a/src/utest/Assert.hx
+++ b/src/utest/Assert.hx
@@ -671,8 +671,8 @@ class Assert {
    * @param pos Code position where the Assert call has been executed. Don't fill it
    * unless you know what you are doing.
    */
-  public static function raises<T>(method:() -> Void, ?type:EitherType<Class<T>, Any>, ?condition:(e:T)->Bool, ?msgNotThrown : String , ?msgWrongType : String, ?msgWrongCondition : String, ?pos : PosInfos) : Bool {
-    #if !js
+  public static function raises<T>(method:() -> Void, ?type:EitherType<Class<T>, Any>, #if (haxe_ver >= 4.2) ?condition:(e:T)->Bool, #end ?msgNotThrown : String , ?msgWrongType : String, #if (haxe_ver >= 4.2) ?msgWrongCondition : String, #end ?pos : PosInfos) : Bool {
+    #if (!js && (haxe_ver >= 4.2))
     if(Reflect.isFunction(type)) {
       condition = (type:Any);
       type = null;
@@ -687,6 +687,7 @@ class Assert {
     } catch (ex) {
       var ex = Std.isOfType(ex, ValueException) ? (cast ex:ValueException).value : (ex:Any);
       inline function checkCondition():Bool {
+        #if (haxe_ver >= 4.2)
         return if(null == condition) {
           pass(pos);
         } else {
@@ -694,6 +695,9 @@ class Assert {
             msgWrongCondition = '$typeDescr is raised, but condition failed';
           isTrue(condition(cast ex), msgWrongCondition, pos);
         }
+        #else
+        return pass(pos);
+        #end
       }
       return if(null == type) {
         checkCondition();

--- a/test/utest/TestAssert.hx
+++ b/test/utest/TestAssert.hx
@@ -106,12 +106,14 @@ class TestAssert extends Test {
       }
   }
 
+  #if (haxe_ver >= 4.2)
   public function testRaisesCondition() {
     success(() -> raises(() -> throw new SampleException('haxe.Exception-based'), SampleException, e -> e.message.indexOf('haxe') >= 0));
     failure(() -> raises(() -> throw new SampleException('haxe.Exception-based'), SampleException, e -> e.message == 'fail'));
     success(() -> raises(() -> throw 'Non-haxe.Exception', String, e -> e.indexOf('haxe') >= 0));
     failure(() -> raises(() -> throw 'Non-haxe.Exception', String, e -> e == 'fail'));
   }
+  #end
 
   public function testIs() {
     var values : Array<Any> = ["str",    1,   0.1,   new TestAssert(), {},      [1]];

--- a/test/utest/TestAssert.hx
+++ b/test/utest/TestAssert.hx
@@ -107,10 +107,10 @@ class TestAssert extends Test {
   }
 
   public function testRaisesCondition() {
-    success(() -> raisesCondition(() -> throw new SampleException('haxe.Exception-based'), SampleException, e -> e.message.indexOf('haxe') >= 0));
-    failure(() -> raisesCondition(() -> throw new SampleException('haxe.Exception-based'), SampleException, e -> e.message == 'fail'));
-    success(() -> raisesCondition(() -> throw 'Non-haxe.Exception', String, e -> e.indexOf('haxe') >= 0));
-    failure(() -> raisesCondition(() -> throw 'Non-haxe.Exception', String, e -> e == 'fail'));
+    success(() -> raises(() -> throw new SampleException('haxe.Exception-based'), SampleException, e -> e.message.indexOf('haxe') >= 0));
+    failure(() -> raises(() -> throw new SampleException('haxe.Exception-based'), SampleException, e -> e.message == 'fail'));
+    success(() -> raises(() -> throw 'Non-haxe.Exception', String, e -> e.indexOf('haxe') >= 0));
+    failure(() -> raises(() -> throw 'Non-haxe.Exception', String, e -> e == 'fail'));
   }
 
   public function testIs() {


### PR DESCRIPTION
I discussed making a macro for this, and while that would handle a wider variety of cases more reliably, Assert.hx is already way too long, and I couldn't bring myself to make it so much longer.

Instead, I found a way to get type `T` from the `type` argument while also allowing the user to pass `Any` type. `EitherType` attempts to unify the left type first, so it will match `T` if possible, and default to `Any` if not.

This only works when `type` comes before `condition`, and since both arguments are optional, it's possible the user will pass only the function, which will be incorrectly interpreted as being `type`, so we have to check for that. Arguably, the same can be said of `msgNotThrown`.

I still recommend changing `type` to `Class<T>` as soon as possible, but until then, this is the next best thing.