### PR TITLE
Merge `raisesCondition()` into `raises()` using `Class<T>`.

### DIFF
--- a/src/utest/Assert.hx
+++ b/src/utest/Assert.hx
@@ -682,6 +682,7 @@ class Assert {
     // } catch(ex:ValueException) {
     //   return handleCatch(ex.value);
     } catch (ex) {
+      var ex = Std.isOfType(ex, ValueException) ? (cast ex:ValueException).value : ex;
       inline function checkCondition():Bool {
         return if(null == condition) {
           pass(pos);
@@ -691,9 +692,6 @@ class Assert {
           isTrue(condition(cast ex), msgWrongCondition, pos);
         }
       }
-      
-      if(Std.isOfType(ex, ValueException))
-        ex = (cast ex:ValueException).value;
       return if(null == type) {
         checkCondition();
       } else {

--- a/src/utest/Assert.hx
+++ b/src/utest/Assert.hx
@@ -685,7 +685,7 @@ class Assert {
     // } catch(ex:ValueException) {
     //   return handleCatch(ex.value);
     } catch (ex) {
-      var ex = Std.isOfType(ex, ValueException) ? (cast ex:ValueException).value : ex;
+      var ex = Std.isOfType(ex, ValueException) ? (cast ex:ValueException).value : (ex:Any);
       inline function checkCondition():Bool {
         return if(null == condition) {
           pass(pos);

--- a/src/utest/Assert.hx
+++ b/src/utest/Assert.hx
@@ -661,8 +661,7 @@ class Assert {
    * @param type The type of the expected error. Defaults to any type (catch all).
    * @param condition The callback which is called upon an exception. The assertion passes
    *      if this callback returns `true`. Otherwise assertion fails. If `type` is specified, that
-   *      will have already been checked before the function is called. In JavaScript, you must
-   *      specify `type`.
+   *      will have already been checked before the function is called.
    * @param msgNotThrown An optional error message used when the function fails to raise the expected
    *      exception. If not passed a default one will be used
    * @param msgWrongType An optional error message used when the function raises the exception but it is
@@ -671,13 +670,7 @@ class Assert {
    * @param pos Code position where the Assert call has been executed. Don't fill it
    * unless you know what you are doing.
    */
-  public static function raises<T>(method:() -> Void, ?type:EitherType<Class<T>, Any>, ?condition:(e:T)->Bool, ?msgNotThrown : String , ?msgWrongType : String, ?msgWrongCondition : String, ?pos : PosInfos) : Bool {
-    #if !js
-    if(Reflect.isFunction(type)) {
-      condition = (type:Any);
-      type = null;
-    }
-    #end
+  public static function raises<T>(method:() -> Void, ?type:Class<T>, ?condition:(e:T)->Bool, ?msgNotThrown : String , ?msgWrongType : String, ?msgWrongCondition : String, ?pos : PosInfos) : Bool {
     var typeDescr = type != null ? "exception of type " + Type.getClassName(type) : "exception";
     try {
       method();

--- a/src/utest/Assert.hx
+++ b/src/utest/Assert.hx
@@ -661,7 +661,8 @@ class Assert {
    * @param type The type of the expected error. Defaults to any type (catch all).
    * @param condition The callback which is called upon an exception. The assertion passes
    *      if this callback returns `true`. Otherwise assertion fails. If `type` is specified, that
-   *      will have already been checked before the function is called.
+   *      will have already been checked before the function is called. In JavaScript, you must
+   *      specify `type`.
    * @param msgNotThrown An optional error message used when the function fails to raise the expected
    *      exception. If not passed a default one will be used
    * @param msgWrongType An optional error message used when the function raises the exception but it is
@@ -671,10 +672,12 @@ class Assert {
    * unless you know what you are doing.
    */
   public static function raises<T>(method:() -> Void, ?type:EitherType<Class<T>, Any>, ?condition:(e:T)->Bool, ?msgNotThrown : String , ?msgWrongType : String, ?msgWrongCondition : String, ?pos : PosInfos) : Bool {
+    #if !js
     if(Reflect.isFunction(type)) {
       condition = (type:Any);
       type = null;
     }
+    #end
     var typeDescr = type != null ? "exception of type " + Type.getClassName(type) : "exception";
     try {
       method();

--- a/src/utest/Assert.hx
+++ b/src/utest/Assert.hx
@@ -659,9 +659,9 @@ class Assert {
    * ```
    * @param method A method that generates the exception.
    * @param type The type of the expected error. Defaults to any type (catch all).
-   * @param condition The callback which is called upon an exception. The assertion passes
-   *      if this callback returns `true`. Otherwise assertion fails. If `type` is specified, that
-   *      will have already been checked before the function is called.
+   * @param condition The callback which is called upon an exception. The assertion passes if this
+   *      callback returns `true`. Otherwise assertion fails. If specified, `type` will have already been
+   *      checked before the function is called.
    * @param msgNotThrown An optional error message used when the function fails to raise the expected
    *      exception. If not passed a default one will be used
    * @param msgWrongType An optional error message used when the function raises the exception but it is
@@ -674,9 +674,6 @@ class Assert {
     var typeDescr = type != null ? "exception of type " + Type.getClassName(type) : "exception";
     try {
       method();
-    // Broken on eval in Haxe 4.3.2: https://github.com/HaxeFoundation/haxe/issues/11321
-    // } catch(ex:ValueException) {
-    //   return handleCatch(ex.value);
     } catch (ex) {
       var ex = Std.isOfType(ex, ValueException) ? (cast ex:ValueException).value : (ex:Any);
       inline function checkCondition():Bool {

--- a/test/utest/TestAssert.hx
+++ b/test/utest/TestAssert.hx
@@ -107,10 +107,10 @@ class TestAssert extends Test {
   }
 
   public function testRaisesCondition() {
-    success(() -> raisesCondition(() -> throw new SampleException('haxe.Exception-based'), SampleException, e -> e.message.indexOf('haxe') >= 0));
-    failure(() -> raisesCondition(() -> throw new SampleException('haxe.Exception-based'), SampleException, e -> e.message == 'fail'));
-    success(() -> raisesCondition(() -> throw 'Non-haxe.Exception', String, e -> e.indexOf('haxe') >= 0));
-    failure(() -> raisesCondition(() -> throw 'Non-haxe.Exception', String, e -> e == 'fail'));
+    success(() -> raises(() -> throw new SampleException('haxe.Exception-based'), SampleException, e -> e.message.indexOf('haxe') >= 0));
+    failure(() -> raises(() -> throw new SampleException('haxe.Exception-based'), SampleException, e -> e.message == 'fail'));
+    success(() -> raises(() -> throw 'Non-haxe.Exception', String, e -> e.indexOf('haxe') >= 0));
+    failure(() -> raises(() -> throw 'Non-haxe.Exception', String, e -> e == 'fail'));
   }
 
   public function testIs() {


### PR DESCRIPTION
Previously, `Assert.raises()` took parameter `type:Any`, but I've changed it to `type:Class<T>`. In theory this is a breaking change, but I argue that it almost certainly won't break any code in practice because there was no use case for passing anything other than a `Class`. `type` gets passed to `Std.isOfType()`, so if it was anything other than a `Class`, the assertion would always fail, prompting the user to fix the error. Now, the prompt will happen at compile time rather than runtime.

This pull request is an alternative to #127. The two are similar, but this one is shorter, requires less documentation, and works in more versions of Haxe.