### PR TITLE
Upgrade to actions/cache@v4.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v2 #https://github.com/actions/checkout
 
     - name: "Cache Haxelib Repository"
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: $RUNNER_TOOL_CACHE/haxe/${{ matrix.haxe }}/x64/lib
         key: ${{ runner.os }}-haxelib-${{ hashFiles('**/haxelib.json') }}


### PR DESCRIPTION
The old version was retired, causing all workflow runs to fail.

https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down